### PR TITLE
Fix intermittent token invalidation with per-install device ID

### DIFF
--- a/cmd/kino/main.go
+++ b/cmd/kino/main.go
@@ -157,7 +157,7 @@ func runSetupFlow(cfg *config.Config, logger *slog.Logger) error {
 	cfg.Server.Type = serverType
 
 	// Run the appropriate auth flow
-	authFlow, err := mediaserver.NewAuthFlow(serverType, logger)
+	authFlow, err := mediaserver.NewAuthFlow(serverType, cfg.Server.DeviceID, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create auth flow: %w", err)
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,9 @@ server:
   # user_id: ""
   # Jellyfin only: Username for display (auto-populated during auth)
   # username: ""
+  # Unique per-install device identifier (auto-generated; do not share
+  # between installs — servers revoke tokens when a device ID is reused)
+  # device_id: ""
 
 # Media Player Configuration
 player:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,11 +29,12 @@ type Config struct {
 
 // ServerConfig holds media server configuration
 type ServerConfig struct {
-	Type     SourceType `mapstructure:"type"`     // "plex" or "jellyfin"
-	URL      string     `mapstructure:"url"`      // Server URL
-	Token    string     `mapstructure:"token"`    // Plex token OR Jellyfin API key
-	UserID   string     `mapstructure:"user_id"`  // Jellyfin only
-	Username string     `mapstructure:"username"` // Jellyfin only (display)
+	Type     SourceType `mapstructure:"type"`      // "plex" or "jellyfin"
+	URL      string     `mapstructure:"url"`       // Server URL
+	Token    string     `mapstructure:"token"`     // Plex token OR Jellyfin API key
+	UserID   string     `mapstructure:"user_id"`   // Jellyfin only
+	Username string     `mapstructure:"username"`  // Jellyfin only (display)
+	DeviceID string     `mapstructure:"device_id"` // Unique per-install device identifier
 }
 
 // PlayerConfig holds media player configuration
@@ -114,7 +117,33 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("error parsing config: %w", err)
 	}
 
+	// Ensure this install has a stable, unique device ID. Media servers
+	// (Jellyfin in particular) revoke tokens when another login reuses the
+	// same device ID, so a shared/static ID causes intermittent auth failures.
+	if cfg.Server.DeviceID == "" {
+		cfg.Server.DeviceID = generateDeviceID()
+		// Persist immediately for already-configured installs so the ID
+		// stays stable across runs. Fresh installs save during setup.
+		if configFile := viper.ConfigFileUsed(); configFile != "" {
+			viper.Set("server.device_id", cfg.Server.DeviceID)
+			if err := viper.WriteConfigAs(configFile); err != nil {
+				return nil, fmt.Errorf("failed to save device ID: %w", err)
+			}
+		}
+	}
+
 	return cfg, nil
+}
+
+// generateDeviceID returns a random unique identifier for this install
+func generateDeviceID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		// Fall back to the legacy static ID; auth still works, just without
+		// per-install uniqueness
+		return "kino-tui-client"
+	}
+	return "kino-" + hex.EncodeToString(buf)
 }
 
 // SaveConfig saves the current configuration to file
@@ -132,6 +161,7 @@ func SaveConfig(cfg *Config) error {
 	viper.Set("server.token", cfg.Server.Token)
 	viper.Set("server.user_id", cfg.Server.UserID)
 	viper.Set("server.username", cfg.Server.Username)
+	viper.Set("server.device_id", cfg.Server.DeviceID)
 
 	// Set player fields
 	viper.Set("player.command", cfg.Player.Command)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadConfigGeneratesDeviceID verifies that an already-configured install
+// without a device_id (pre-existing config.yaml) gets a unique ID generated
+// and persisted, so the ID stays stable across runs.
+func TestLoadConfigGeneratesDeviceID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("APPDATA", home) // windows
+
+	configDir := filepath.Join(home, ".config", "kino")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	existing := `server:
+  type: "jellyfin"
+  url: "http://localhost:8096"
+  token: "abc123"
+  user_id: "user1"
+`
+	configFile := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Server.DeviceID == "" {
+		t.Fatal("expected device ID to be generated")
+	}
+	if cfg.Server.DeviceID == "kino-tui-client" {
+		t.Fatal("device ID should be unique, not the legacy shared ID")
+	}
+	if !strings.HasPrefix(cfg.Server.DeviceID, "kino-") {
+		t.Fatalf("unexpected device ID format: %q", cfg.Server.DeviceID)
+	}
+
+	// Must be persisted so the same ID is used on the next run
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), cfg.Server.DeviceID) {
+		t.Fatalf("device ID %q not persisted to config file:\n%s", cfg.Server.DeviceID, data)
+	}
+
+	// Existing credentials must survive the rewrite
+	if !strings.Contains(string(data), "abc123") {
+		t.Fatalf("token lost when persisting device ID:\n%s", data)
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -10,6 +10,6 @@ var (
 	// ErrServerOffline indicates the media server is unreachable
 	ErrServerOffline = errors.New("media server is unreachable")
 
-	// ErrAuthFailed indicates authentication failed
-	ErrAuthFailed = errors.New("authentication token is invalid")
+	// ErrAuthFailed indicates the server rejected our token (revoked or expired)
+	ErrAuthFailed = errors.New("authentication token is invalid or expired")
 )

--- a/internal/mediaserver/auth.go
+++ b/internal/mediaserver/auth.go
@@ -31,13 +31,14 @@ type AuthFlow interface {
 // NewAuthFlow creates the appropriate AuthFlow based on server type.
 // - Plex: PIN-based OAuth flow (display PIN -> user visits plex.tv/link -> poll for token)
 // - Jellyfin: Username/password authentication
-func NewAuthFlow(serverType config.SourceType, logger *slog.Logger) (AuthFlow, error) {
+// The deviceID uniquely identifies this install to the server.
+func NewAuthFlow(serverType config.SourceType, deviceID string, logger *slog.Logger) (AuthFlow, error) {
 	switch serverType {
 	case config.SourceTypePlex:
-		return &plexAuthAdapter{inner: plex.NewAuthFlow(logger)}, nil
+		return &plexAuthAdapter{inner: plex.NewAuthFlow(deviceID, logger)}, nil
 
 	case config.SourceTypeJellyfin:
-		return &jellyfinAuthAdapter{inner: jellyfin.NewAuthFlow(logger)}, nil
+		return &jellyfinAuthAdapter{inner: jellyfin.NewAuthFlow(deviceID, logger)}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown server type: %s", serverType)

--- a/internal/mediaserver/client.go
+++ b/internal/mediaserver/client.go
@@ -43,7 +43,7 @@ func NewClient(cfg *config.Config, logger *slog.Logger) (MediaSource, error) {
 
 	switch cfg.Server.Type {
 	case config.SourceTypePlex:
-		client := plex.NewClient(cfg.Server.URL, cfg.Server.Token, logger)
+		client := plex.NewClient(cfg.Server.URL, cfg.Server.Token, cfg.Server.DeviceID, logger)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -59,7 +59,7 @@ func NewClient(cfg *config.Config, logger *slog.Logger) (MediaSource, error) {
 		if cfg.Server.UserID == "" {
 			return nil, fmt.Errorf("Jellyfin requires user ID")
 		}
-		return jellyfin.NewClient(cfg.Server.URL, cfg.Server.Token, cfg.Server.UserID, logger), nil
+		return jellyfin.NewClient(cfg.Server.URL, cfg.Server.Token, cfg.Server.UserID, cfg.Server.DeviceID, logger), nil
 
 	default:
 		return nil, fmt.Errorf("unknown server type: %s", cfg.Server.Type)

--- a/internal/mediaserver/jellyfin/auth.go
+++ b/internal/mediaserver/jellyfin/auth.go
@@ -39,17 +39,19 @@ const (
 
 // AuthFlow handles Jellyfin username/password authentication
 type AuthFlow struct {
+	deviceID   string
 	logger     *slog.Logger
 	httpClient *http.Client
 }
 
 // NewAuthFlow creates a new Jellyfin authentication flow
-func NewAuthFlow(logger *slog.Logger) *AuthFlow {
+func NewAuthFlow(deviceID string, logger *slog.Logger) *AuthFlow {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &AuthFlow{
-		logger: logger,
+		deviceID: deviceID,
+		logger:   logger,
 		httpClient: &http.Client{
 			Timeout: authTimeout,
 		},
@@ -119,7 +121,7 @@ func (f *AuthFlow) authenticate(ctx context.Context, serverURL, username, passwo
 
 	// Set required headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader("")) // No token yet
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader("", f.deviceID)) // No token yet
 
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
@@ -154,12 +156,18 @@ func (f *AuthFlow) authenticate(ctx context.Context, serverURL, username, passwo
 	}, nil
 }
 
-// buildAuthHeader constructs the X-Emby-Authorization header
-func buildAuthHeader(token string) string {
+// buildAuthHeader constructs the X-Emby-Authorization header.
+// The device ID must be unique per install: Jellyfin revokes existing
+// tokens when a new login reuses the same device ID, so a shared static
+// ID causes intermittent token invalidation across installs.
+func buildAuthHeader(token, deviceID string) string {
+	if deviceID == "" {
+		deviceID = "kino-tui-client" // legacy fallback
+	}
 	parts := []string{
 		`MediaBrowser Client="Kino"`,
 		`Device="CLI"`,
-		`DeviceId="kino-tui-client"`,
+		fmt.Sprintf(`DeviceId="%s"`, deviceID),
 		`Version="1.0.0"`,
 	}
 

--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -26,19 +26,21 @@ type Client struct {
 	baseURL    string
 	token      string
 	userID     string
+	deviceID   string
 	httpClient *http.Client
 	logger     *slog.Logger
 }
 
 // NewClient creates a new Jellyfin API client
-func NewClient(baseURL, token, userID string, logger *slog.Logger) *Client {
+func NewClient(baseURL, token, userID, deviceID string, logger *slog.Logger) *Client {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
-		userID:  userID,
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		token:    token,
+		userID:   userID,
+		deviceID: deviceID,
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
@@ -79,7 +81,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, query url.V
 
 		// Set Jellyfin auth headers
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+		req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 		c.logger.Debug("jellyfin request", "method", method, "url", reqURL, "attempt", attempt)
 
@@ -407,7 +409,7 @@ func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -431,7 +433,7 @@ func (c *Client) MarkUnplayed(ctx context.Context, itemID string) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -522,7 +524,7 @@ func (c *Client) CreatePlaylist(ctx context.Context, title string, itemIDs []str
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -573,7 +575,7 @@ func (c *Client) AddToPlaylist(ctx context.Context, playlistID string, itemIDs [
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -600,7 +602,7 @@ func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, item
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -624,7 +626,7 @@ func (c *Client) DeletePlaylist(ctx context.Context, playlistID string) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token))
+	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/mediaserver/plex/auth.go
+++ b/internal/mediaserver/plex/auth.go
@@ -34,16 +34,18 @@ const (
 
 // AuthClient handles Plex authentication
 type AuthClient struct {
+	clientID   string
 	httpClient *http.Client
 	logger     *slog.Logger
 }
 
 // NewAuthClient creates a new authentication client
-func NewAuthClient(logger *slog.Logger) *AuthClient {
+func NewAuthClient(clientID string, logger *slog.Logger) *AuthClient {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &AuthClient{
+		clientID: normalizeClientID(clientID),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -58,7 +60,7 @@ func (a *AuthClient) GetPIN(ctx context.Context) (pin string, id int, err error)
 	data := url.Values{}
 	data.Set("strong", "false")
 	data.Set("X-Plex-Product", "Kino")
-	data.Set("X-Plex-Client-Identifier", clientID)
+	data.Set("X-Plex-Client-Identifier", a.clientID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
 	if err != nil {
@@ -66,7 +68,7 @@ func (a *AuthClient) GetPIN(ctx context.Context) (pin string, id int, err error)
 	}
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", a.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
@@ -112,7 +114,7 @@ func (a *AuthClient) CheckPIN(ctx context.Context, pinID int) (token string, cla
 	}
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", a.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
@@ -189,9 +191,9 @@ type AuthFlow struct {
 }
 
 // NewAuthFlow creates a new Plex authentication flow
-func NewAuthFlow(logger *slog.Logger) *AuthFlow {
+func NewAuthFlow(clientID string, logger *slog.Logger) *AuthFlow {
 	return &AuthFlow{
-		client: NewAuthClient(logger),
+		client: NewAuthClient(clientID, logger),
 	}
 }
 

--- a/internal/mediaserver/plex/client.go
+++ b/internal/mediaserver/plex/client.go
@@ -19,27 +19,39 @@ import (
 const (
 	defaultTimeout = 30 * time.Second
 	userAgent      = "Kino/1.0"
-	clientID       = "kino-tui-client"
 )
+
+// normalizeClientID ensures a usable X-Plex-Client-Identifier.
+// The identifier must be unique per install: plex.tv tracks devices by it,
+// so a shared static ID makes every kino install look like the same device
+// and re-linking anywhere can invalidate previously issued tokens.
+func normalizeClientID(clientID string) string {
+	if clientID == "" {
+		return "kino-tui-client" // legacy fallback
+	}
+	return clientID
+}
 
 // Client implements domain.LibraryRepository, domain.SearchRepository,
 // domain.MetadataRepository, and domain.Scrobbler for Plex
 type Client struct {
 	baseURL           string
 	token             string
+	clientID          string // unique per-install X-Plex-Client-Identifier
 	machineIdentifier string // fetched from /identity on init
 	httpClient        *http.Client
 	logger            *slog.Logger
 }
 
 // NewClient creates a new Plex API client
-func NewClient(baseURL, token string, logger *slog.Logger) *Client {
+func NewClient(baseURL, token, clientID string, logger *slog.Logger) *Client {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &Client{
-		baseURL: baseURL,
-		token:   token,
+		baseURL:  baseURL,
+		token:    token,
+		clientID: normalizeClientID(clientID),
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
@@ -93,7 +105,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, query url.V
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
@@ -420,7 +432,7 @@ func (c *Client) CreatePlaylist(ctx context.Context, title string, itemIDs []str
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
@@ -485,7 +497,7 @@ func (c *Client) AddToPlaylist(ctx context.Context, playlistID string, itemIDs [
 
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-Plex-Token", c.token)
-		req.Header.Set("X-Plex-Client-Identifier", clientID)
+		req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 		req.Header.Set("X-Plex-Product", "Kino")
 		req.Header.Set("X-Plex-Version", "1.0")
 		req.Header.Set("User-Agent", userAgent)
@@ -544,7 +556,7 @@ func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, item
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
@@ -575,7 +587,7 @@ func (c *Client) DeletePlaylist(ctx context.Context, playlistID string) error {
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -14,6 +15,10 @@ import (
 	"github.com/mmcdole/kino/internal/search"
 	"github.com/mmcdole/kino/internal/tui/components"
 )
+
+// authFailedStatusMsg tells the user how to recover from a revoked/expired
+// token. Shown persistently (not auto-cleared) since action is required.
+const authFailedStatusMsg = "Session expired or revoked — press L to log out, then run kino to sign in again"
 
 // ApplicationState represents the current state of the application
 type ApplicationState int
@@ -353,9 +358,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ErrMsg:
 		m.clearNavPlan()
-		m.StatusMsg = msg.Error()
 		m.StatusIsErr = true
 		m.Loading = false
+		if errors.Is(msg.Err, domain.ErrAuthFailed) {
+			// Actionable, persistent message: the token was revoked/expired
+			// and the user must re-authenticate
+			m.StatusMsg = authFailedStatusMsg
+			return m, nil
+		}
+		m.StatusMsg = msg.Error()
 		cmds = append(cmds, ClearStatusCmd(5*time.Second))
 		return m, tea.Batch(cmds...)
 
@@ -378,6 +389,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			state.Error = msg.Error
 			m.SyncingCount--
 			slog.Error("library sync failed", "libraryID", msg.LibraryID, "error", msg.Error)
+			if errors.Is(msg.Error, domain.ErrAuthFailed) {
+				m.StatusMsg = authFailedStatusMsg
+				m.StatusIsErr = true
+			}
 		} else {
 			state.Loaded = msg.Loaded
 			state.Total = msg.Total


### PR DESCRIPTION
Fixes #26

## Problem

Every kino install shared a hardcoded device identity (`kino-tui-client`) — sent as `DeviceId` to Jellyfin and `X-Plex-Client-Identifier` to Plex. Jellyfin revokes a device's existing access tokens when a new login arrives with the same device ID, so signing in from a second machine (or any other kino install on a shared server) silently invalidated your saved token. The next request would 401 and surface as an unexplained `authentication token is invalid`.

## Changes

- Generate a random per-install device ID (`kino-<hex>`) and persist it as `server.device_id` in config.yaml. Already-configured installs get one generated and saved on next launch; existing tokens keep working since both servers authenticate by token alone.
- Thread the ID through both backends' clients and auth flows (Plex PIN create/claim must use the same identifier).
- Replace the cryptic 5-second error flash on 401 with a persistent, actionable message: "Session expired or revoked — press L to log out, then run kino to sign in again."
- Document `device_id` in config.example.yaml.

## Testing

- `go build ./... && go vet ./... && go test ./...`
- New test covering device-ID migration for existing configs (generated, persisted, token preserved)
- Drove the real binary in a pty against a fake Jellyfin server returning 401: verified the unique `DeviceId` in the auth header and the new persistent error message rendering in the TUI