### PR TITLE
Verify library item count during cache validation

### DIFF
--- a/internal/domain/library.go
+++ b/internal/domain/library.go
@@ -10,4 +10,10 @@ type LibraryClient interface {
 	GetMixedContent(ctx context.Context, libID string, offset, limit int) ([]ListItem, int, error)
 	GetSeasons(ctx context.Context, showID string) ([]*Season, error)
 	GetEpisodes(ctx context.Context, seasonID string) ([]*MediaItem, error)
+
+	// GetLibraryItemCount returns the number of top-level items in a library
+	// (movies and/or shows, matching what a full sync would fetch) without
+	// downloading them. Used for cheap cache validation: library timestamps
+	// don't reliably change when items are added.
+	GetLibraryItemCount(ctx context.Context, libID, libType string) (int, error)
 }

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -43,11 +43,23 @@ func (s *Service) SyncLibrary(
 	lib domain.Library,
 	onProgress domain.ProgressFunc,
 ) (domain.SyncResult, error) {
-	// 1. Freshness check
+	// 1. Freshness check. The library timestamp alone is not enough: servers
+	// don't reliably bump it when items are added (Jellyfin's Views only
+	// expose the library's creation date), so also verify the item count
+	// with a cheap metadata-only request.
 	if s.store.IsValid(lib.ID, lib.UpdatedAt) {
 		count := s.getCachedCount(lib)
-		s.logger.Debug("cache fresh", "libID", lib.ID, "count", count)
-		return domain.SyncResult{LibraryID: lib.ID, FromCache: true, Count: count}, nil
+		serverCount, err := s.client.GetLibraryItemCount(ctx, lib.ID, lib.Type)
+		if err != nil {
+			// Can't verify; serve cache rather than fail or refetch blindly
+			s.logger.Warn("item count check failed, serving cache", "libID", lib.ID, "error", err)
+			return domain.SyncResult{LibraryID: lib.ID, FromCache: true, Count: count}, nil
+		}
+		if serverCount == count {
+			s.logger.Debug("cache fresh", "libID", lib.ID, "count", count)
+			return domain.SyncResult{LibraryID: lib.ID, FromCache: true, Count: count}, nil
+		}
+		s.logger.Debug("item count changed", "libID", lib.ID, "cached", count, "server", serverCount)
 	}
 
 	// 2. Fetch based on library type

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -1,0 +1,154 @@
+package library
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mmcdole/kino/internal/domain"
+	"github.com/mmcdole/kino/internal/store"
+)
+
+// fakeClient implements domain.LibraryClient with canned data
+type fakeClient struct {
+	movies     []*domain.MediaItem
+	count      int
+	countErr   error
+	fetchCalls int
+	countCalls int
+}
+
+func (f *fakeClient) GetLibraries(ctx context.Context) ([]domain.Library, error) { return nil, nil }
+
+func (f *fakeClient) GetMovies(ctx context.Context, libID string, offset, limit int) ([]*domain.MediaItem, int, error) {
+	f.fetchCalls++
+	return f.movies, len(f.movies), nil
+}
+
+func (f *fakeClient) GetShows(ctx context.Context, libID string, offset, limit int) ([]*domain.Show, int, error) {
+	return nil, 0, nil
+}
+
+func (f *fakeClient) GetMixedContent(ctx context.Context, libID string, offset, limit int) ([]domain.ListItem, int, error) {
+	return nil, 0, nil
+}
+
+func (f *fakeClient) GetSeasons(ctx context.Context, showID string) ([]*domain.Season, error) {
+	return nil, nil
+}
+
+func (f *fakeClient) GetEpisodes(ctx context.Context, seasonID string) ([]*domain.MediaItem, error) {
+	return nil, nil
+}
+
+func (f *fakeClient) GetLibraryItemCount(ctx context.Context, libID, libType string) (int, error) {
+	f.countCalls++
+	return f.count, f.countErr
+}
+
+func newTestService(t *testing.T, client *fakeClient) (*Service, domain.Store) {
+	t.Helper()
+	st, err := store.NewLibraryStore("", "") // memory-only
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return NewService(client, st, nil), st
+}
+
+func movie(id string) *domain.MediaItem {
+	return &domain.MediaItem{ID: id, Title: id, Type: domain.MediaTypeMovie}
+}
+
+// TestSyncLibraryDetectsNewItems reproduces issue #25: the server's library
+// timestamp doesn't change when items are added (Jellyfin never bumps it),
+// so the count check must catch the new item.
+func TestSyncLibraryDetectsNewItems(t *testing.T) {
+	client := &fakeClient{movies: []*domain.MediaItem{movie("a"), movie("b")}, count: 2}
+	svc, _ := newTestService(t, client)
+
+	lib := domain.Library{ID: "lib1", Type: "movie", UpdatedAt: 100}
+
+	// Initial sync populates the cache
+	res, err := svc.SyncLibrary(context.Background(), lib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FromCache || res.Count != 2 {
+		t.Fatalf("initial sync: got %+v", res)
+	}
+
+	// Second sync, nothing changed: timestamp valid, counts match -> cache
+	res, err = svc.SyncLibrary(context.Background(), lib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.FromCache || res.Count != 2 {
+		t.Fatalf("unchanged sync: got %+v", res)
+	}
+	if client.fetchCalls != 1 {
+		t.Fatalf("expected no refetch, got %d fetch calls", client.fetchCalls)
+	}
+
+	// New movie added on the server, but timestamp UNCHANGED (the bug)
+	client.movies = append(client.movies, movie("c"))
+	client.count = 3
+
+	res, err = svc.SyncLibrary(context.Background(), lib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FromCache {
+		t.Fatal("stale cache served despite item count change")
+	}
+	if res.Count != 3 {
+		t.Fatalf("expected 3 items after refetch, got %d", res.Count)
+	}
+}
+
+// TestSyncLibraryTimestampInvalidates verifies the original timestamp path
+// still triggers a refetch without needing the count check.
+func TestSyncLibraryTimestampInvalidates(t *testing.T) {
+	client := &fakeClient{movies: []*domain.MediaItem{movie("a")}, count: 1}
+	svc, _ := newTestService(t, client)
+
+	if _, err := svc.SyncLibrary(context.Background(), domain.Library{ID: "lib1", Type: "movie", UpdatedAt: 100}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	countCallsBefore := client.countCalls
+	res, err := svc.SyncLibrary(context.Background(), domain.Library{ID: "lib1", Type: "movie", UpdatedAt: 200}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FromCache {
+		t.Fatal("expected refetch for newer server timestamp")
+	}
+	if client.countCalls != countCallsBefore {
+		t.Fatal("count check should be skipped when timestamp already invalidates")
+	}
+}
+
+// TestSyncLibraryCountCheckFailureServesCache verifies we degrade gracefully:
+// if the count request fails, the cache is served rather than erroring.
+func TestSyncLibraryCountCheckFailureServesCache(t *testing.T) {
+	client := &fakeClient{movies: []*domain.MediaItem{movie("a")}, count: 1}
+	svc, _ := newTestService(t, client)
+
+	lib := domain.Library{ID: "lib1", Type: "movie", UpdatedAt: 100}
+	if _, err := svc.SyncLibrary(context.Background(), lib, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	client.countErr = errors.New("server offline")
+	res, err := svc.SyncLibrary(context.Background(), lib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.FromCache || res.Count != 1 {
+		t.Fatalf("expected cache to be served on count failure, got %+v", res)
+	}
+	if client.fetchCalls != 1 {
+		t.Fatalf("expected no refetch, got %d fetch calls", client.fetchCalls)
+	}
+}

--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -264,6 +264,38 @@ func (c *Client) GetMixedContent(ctx context.Context, libID string, offset, limi
 	return items, resp.TotalRecordCount, nil
 }
 
+// GetLibraryItemCount returns the total item count for a library without
+// fetching the items. Limit=1 keeps the response tiny while still populating
+// TotalRecordCount.
+func (c *Client) GetLibraryItemCount(ctx context.Context, libID, libType string) (int, error) {
+	query := url.Values{}
+	query.Set("ParentId", libID)
+	switch libType {
+	case "movie":
+		query.Set("IncludeItemTypes", "Movie")
+	case "show":
+		query.Set("IncludeItemTypes", "Series")
+	default: // mixed
+		query.Set("IncludeItemTypes", "Movie,Series")
+	}
+	query.Set("Recursive", "true")
+	query.Set("Limit", "1")
+	query.Set("EnableTotalRecordCount", "true")
+
+	path := fmt.Sprintf("/Users/%s/Items", c.userID)
+	body, err := c.doRequest(ctx, http.MethodGet, path, query)
+	if err != nil {
+		return 0, err
+	}
+
+	var resp ItemsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return resp.TotalRecordCount, nil
+}
+
 // GetSeasons returns all seasons for a TV show
 func (c *Client) GetSeasons(ctx context.Context, showID string) ([]*domain.Season, error) {
 	query := url.Values{}

--- a/internal/mediaserver/plex/client.go
+++ b/internal/mediaserver/plex/client.go
@@ -223,6 +223,28 @@ func (c *Client) GetShows(ctx context.Context, libID string, offset, limit int) 
 	return MapShows(container.Metadata, c.baseURL), totalSize, nil
 }
 
+// GetLibraryItemCount returns the total item count for a library section
+// without fetching the items (X-Plex-Container-Size=0 returns only totalSize).
+// libType is unused: /all already returns the section's native item type.
+func (c *Client) GetLibraryItemCount(ctx context.Context, libID, libType string) (int, error) {
+	query := url.Values{}
+	query.Set("X-Plex-Container-Start", "0")
+	query.Set("X-Plex-Container-Size", "0")
+
+	path := fmt.Sprintf("/library/sections/%s/all", libID)
+	body, err := c.doRequest(ctx, http.MethodGet, path, query)
+	if err != nil {
+		return 0, err
+	}
+
+	container, err := c.parseResponse(body)
+	if err != nil {
+		return 0, err
+	}
+
+	return container.TotalSize, nil
+}
+
 // GetMixedContent returns paginated content (movies AND shows) from a library.
 // Note: Plex doesn't truly support "mixed" libraries at the API level like Jellyfin,
 // so this method fetches all items and returns both types. For pure movie or show


### PR DESCRIPTION
Fixes #25

## Root cause (confirmed)

Cache freshness was `storedTS >= lib.UpdatedAt`. For **Jellyfin**, `Library.UpdatedAt` is mapped from the view's `DateCreated` (`internal/mediaserver/jellyfin/mapper.go`) — a value that never changes after the library is created. So after the first sync, the timestamp check passed forever and new items only appeared after a manual refresh. **Plex** uses `contentChangedAt`, which mostly works but isn't bumped by every scan type.

## Fix

When the timestamp check says the cache is fresh, verify the library's item count with a cheap metadata-only request before trusting it:

- Jellyfin: `/Users/{id}/Items?ParentId={lib}&Recursive=true&Limit=1` → `TotalRecordCount`
- Plex: `/library/sections/{id}/all?X-Plex-Container-Size=0` → `totalSize`

Count mismatch → full refetch. Count request fails (e.g. server offline) → serve cache as before. The timestamp path still short-circuits straight to refetch without the extra request. Cost is one tiny request per library per launch.

This catches added and removed items. In-place metadata edits with an unchanged count on Jellyfin still won't invalidate automatically (nothing cheap on the Views API signals that), but manual refresh covers it as before.

## Testing

- New service tests with a fake client + memory store: unchanged count serves cache, changed count with an unchanged timestamp refetches (the #25 repro), newer timestamp skips the count check, count-request failure degrades to cache.
- Drove the real binary against a fake Jellyfin server across three launches: cold cache → full fetch; unchanged → count check only, served from cache; third movie added with unchanged library timestamp → count mismatch detected and full refetch (`item count changed cached=2 server=3` in debug log).