### PR TITLE
Update watch state in place instead of invalidating all caches

### DIFF
--- a/internal/domain/store.go
+++ b/internal/domain/store.go
@@ -34,6 +34,12 @@ type Store interface {
 	// === Freshness ===
 	IsValid(libID string, serverTS int64) bool
 
+	// === In-place updates ===
+	// SetWatchState patches a media item's watch state everywhere it is
+	// cached (and adjusts season/show unwatched counters) without
+	// invalidating anything.
+	SetWatchState(itemID string, played bool)
+
 	// === Invalidation ===
 	InvalidateLibrary(libID string)
 	InvalidateShow(libID, showID string)

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -172,6 +172,13 @@ func (s *Service) FetchEpisodes(ctx context.Context, libID, showID, seasonID str
 	return episodes, nil
 }
 
+// SetWatchState patches the cached watch state for an item in place,
+// avoiding cache invalidation. The next sync reconciles with the server.
+func (s *Service) SetWatchState(itemID string, played bool) {
+	s.store.SetWatchState(itemID, played)
+	s.logger.Debug("patched cached watch state", "itemID", itemID, "played", played)
+}
+
 func (s *Service) InvalidateLibrary(libID string) {
 	s.store.InvalidateLibrary(libID)
 	s.logger.Info("invalidated library cache", "libID", libID)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -327,6 +327,236 @@ func (s *LibraryStore) IsValid(libID string, serverTS int64) bool {
 	return storedTS >= serverTS
 }
 
+// === In-place watch state updates ===
+
+// SetWatchState patches a media item's watch state in place everywhere it is
+// cached (library lists, episode lists, mixed content, playlist items) and
+// adjusts the containing season/show unwatched counters. Cached data stays
+// warm — nothing is invalidated; the next real sync reconciles with the
+// server.
+func (s *LibraryStore) SetWatchState(itemID string, played bool) {
+	var flipped bool
+	var showID, seasonID string
+
+	patch := func(m *domain.MediaItem) bool {
+		if m == nil || m.ID != itemID {
+			return false
+		}
+		if m.IsPlayed != played {
+			flipped = true
+			if m.ShowID != "" {
+				showID = m.ShowID
+				seasonID = m.ParentID
+			}
+		}
+		m.IsPlayed = played
+		m.ViewOffset = 0
+		return true
+	}
+
+	// []*MediaItem payloads: movie lists, episode lists, playlist items
+	patchItemList := func(key string, data []byte) []byte {
+		var items []*domain.MediaItem
+		if json.Unmarshal(data, &items) != nil {
+			return nil
+		}
+		changed := false
+		for _, m := range items {
+			if patch(m) {
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		out, err := json.Marshal(items)
+		if err != nil {
+			return nil
+		}
+		return out
+	}
+
+	s.updateEach(bucketEpisodes, nil, patchItemList)
+	s.updateEach(bucketContent, keySuffix(":movies"), patchItemList)
+	s.updateEach(bucketPlaylists, keyPrefix("items:"), patchItemList)
+	s.updateEach(bucketContent, keySuffix(":mixed"), func(key string, data []byte) []byte {
+		var wrappers []listItemWrapper
+		if json.Unmarshal(data, &wrappers) != nil {
+			return nil
+		}
+		changed := false
+		for i := range wrappers {
+			if patch(wrappers[i].Movie) {
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		out, err := json.Marshal(wrappers)
+		if err != nil {
+			return nil
+		}
+		return out
+	})
+
+	// Adjust unwatched counters on the containing season and show
+	if !flipped || showID == "" {
+		return
+	}
+	delta := 1
+	if played {
+		delta = -1
+	}
+
+	s.updateEach(bucketSeasons, nil, func(key string, data []byte) []byte {
+		var seasons []*domain.Season
+		if json.Unmarshal(data, &seasons) != nil {
+			return nil
+		}
+		changed := false
+		for _, season := range seasons {
+			if season != nil && season.ID == seasonID {
+				season.UnwatchedCount = clampCount(season.UnwatchedCount+delta, season.EpisodeCount)
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		out, err := json.Marshal(seasons)
+		if err != nil {
+			return nil
+		}
+		return out
+	})
+
+	adjustShow := func(show *domain.Show) bool {
+		if show == nil || show.ID != showID {
+			return false
+		}
+		show.UnwatchedCount = clampCount(show.UnwatchedCount+delta, show.EpisodeCount)
+		return true
+	}
+	s.updateEach(bucketContent, keySuffix(":shows"), func(key string, data []byte) []byte {
+		var shows []*domain.Show
+		if json.Unmarshal(data, &shows) != nil {
+			return nil
+		}
+		changed := false
+		for _, show := range shows {
+			if adjustShow(show) {
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		out, err := json.Marshal(shows)
+		if err != nil {
+			return nil
+		}
+		return out
+	})
+	s.updateEach(bucketContent, keySuffix(":mixed"), func(key string, data []byte) []byte {
+		var wrappers []listItemWrapper
+		if json.Unmarshal(data, &wrappers) != nil {
+			return nil
+		}
+		changed := false
+		for i := range wrappers {
+			if adjustShow(wrappers[i].Show) {
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		out, err := json.Marshal(wrappers)
+		if err != nil {
+			return nil
+		}
+		return out
+	})
+}
+
+func clampCount(n, max int) int {
+	if n < 0 {
+		return 0
+	}
+	if max > 0 && n > max {
+		return max
+	}
+	return n
+}
+
+func keySuffix(suffix string) func(string) bool {
+	return func(k string) bool { return strings.HasSuffix(k, suffix) }
+}
+
+func keyPrefix(prefix string) func(string) bool {
+	return func(k string) bool { return strings.HasPrefix(k, prefix) }
+}
+
+// updateEach applies transform to every key in a bucket (optionally filtered);
+// a non-nil result is written back to both BoltDB and the memory cache.
+func (s *LibraryStore) updateEach(bucket []byte, keyFilter func(string) bool, transform func(key string, data []byte) []byte) {
+	type kv struct {
+		k string
+		v []byte
+	}
+	var pairs []kv
+
+	if s.db != nil {
+		s.db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket(bucket)
+			if b == nil {
+				return nil
+			}
+			return b.ForEach(func(k, v []byte) error {
+				key := string(k)
+				if keyFilter != nil && !keyFilter(key) {
+					return nil
+				}
+				data := make([]byte, len(v))
+				copy(data, v)
+				pairs = append(pairs, kv{key, data})
+				return nil
+			})
+		})
+	} else {
+		// Memory-only mode: enumerate the cache map
+		cachePrefix := string(bucket) + ":"
+		s.mu.RLock()
+		for k, v := range s.cache {
+			if !strings.HasPrefix(k, cachePrefix) {
+				continue
+			}
+			key := strings.TrimPrefix(k, cachePrefix)
+			if keyFilter != nil && !keyFilter(key) {
+				continue
+			}
+			pairs = append(pairs, kv{key, v})
+		}
+		s.mu.RUnlock()
+	}
+
+	for _, p := range pairs {
+		newData := transform(p.k, p.v)
+		if newData == nil {
+			continue
+		}
+		s.mu.Lock()
+		s.cache[string(bucket)+":"+p.k] = newData
+		s.mu.Unlock()
+		if s.db != nil {
+			s.db.Update(func(tx *bolt.Tx) error {
+				return tx.Bucket(bucket).Put([]byte(p.k), newData)
+			})
+		}
+	}
+}
+
 // === Cascade Invalidation (hierarchical prefix deletion) ===
 
 // InvalidateLibrary wipes library content + ALL seasons + ALL episodes in that library

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/mmcdole/kino/internal/domain"
+)
+
+func seedStore(t *testing.T, dir string) *LibraryStore {
+	t.Helper()
+	s, err := NewLibraryStore(dir, "http://test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	movie := &domain.MediaItem{ID: "mov1", Title: "Movie One", Type: domain.MediaTypeMovie}
+	episode := &domain.MediaItem{
+		ID: "ep1", Title: "Episode One", Type: domain.MediaTypeEpisode,
+		ShowID: "show1", ParentID: "season1", ViewOffset: 300,
+	}
+	show := &domain.Show{ID: "show1", Title: "Show One", EpisodeCount: 10, UnwatchedCount: 5}
+	season := &domain.Season{ID: "season1", ShowID: "show1", EpisodeCount: 10, UnwatchedCount: 5}
+
+	if err := s.SaveMovies("lib1", []*domain.MediaItem{movie}, 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveShows("lib2", []*domain.Show{show}, 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveSeasons("lib2", "show1", []*domain.Season{season}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveEpisodes("lib2", "show1", "season1", []*domain.MediaItem{episode}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePlaylistItems("pl1", []*domain.MediaItem{
+		{ID: "mov1", Title: "Movie One", Type: domain.MediaTypeMovie},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func testWatchState(t *testing.T, s *LibraryStore) {
+	t.Helper()
+
+	// Toggle an episode watched: item patched, season + show counters drop
+	s.SetWatchState("ep1", true)
+
+	eps, ok := s.GetEpisodes("lib2", "show1", "season1")
+	if !ok || len(eps) != 1 {
+		t.Fatal("episodes missing after patch")
+	}
+	if !eps[0].IsPlayed || eps[0].ViewOffset != 0 {
+		t.Fatalf("episode not patched: %+v", eps[0])
+	}
+
+	seasons, _ := s.GetSeasons("lib2", "show1")
+	if seasons[0].UnwatchedCount != 4 {
+		t.Fatalf("season unwatched = %d, want 4", seasons[0].UnwatchedCount)
+	}
+	shows, _ := s.GetShows("lib2")
+	if shows[0].UnwatchedCount != 4 {
+		t.Fatalf("show unwatched = %d, want 4", shows[0].UnwatchedCount)
+	}
+
+	// Toggling the same state again must not shift counters
+	s.SetWatchState("ep1", true)
+	seasons, _ = s.GetSeasons("lib2", "show1")
+	if seasons[0].UnwatchedCount != 4 {
+		t.Fatalf("idempotency broken: season unwatched = %d", seasons[0].UnwatchedCount)
+	}
+
+	// Unwatch restores the counters
+	s.SetWatchState("ep1", false)
+	seasons, _ = s.GetSeasons("lib2", "show1")
+	shows, _ = s.GetShows("lib2")
+	if seasons[0].UnwatchedCount != 5 || shows[0].UnwatchedCount != 5 {
+		t.Fatalf("counters not restored: season=%d show=%d",
+			seasons[0].UnwatchedCount, shows[0].UnwatchedCount)
+	}
+
+	// A movie is patched in the library list AND its playlist copy
+	s.SetWatchState("mov1", true)
+	movies, _ := s.GetMovies("lib1")
+	if !movies[0].IsPlayed {
+		t.Fatal("movie not patched in library list")
+	}
+	plItems, _ := s.GetPlaylistItems("pl1")
+	if !plItems[0].IsPlayed {
+		t.Fatal("movie not patched in playlist items")
+	}
+
+	// Freshness timestamp untouched — no invalidation happened
+	if !s.IsValid("lib1", 100) {
+		t.Fatal("watch-state patch must not invalidate the library")
+	}
+}
+
+func TestSetWatchStateBolt(t *testing.T) {
+	testWatchState(t, seedStore(t, t.TempDir()))
+}
+
+func TestSetWatchStateMemoryOnly(t *testing.T) {
+	testWatchState(t, seedStore(t, ""))
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -344,15 +344,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case MarkWatchedMsg:
 		m.StatusMsg = "Marked watched: " + msg.Title
-		// Refresh to update watch status indicators
-		cmds = append(cmds, m.refreshCurrentView())
+		m.applyWatchState(msg.ItemID, true)
 		cmds = append(cmds, ClearStatusCmd(3*time.Second))
 		return m, tea.Batch(cmds...)
 
 	case MarkUnwatchedMsg:
 		m.StatusMsg = "Marked unwatched: " + msg.Title
-		// Refresh to update watch status indicators
-		cmds = append(cmds, m.refreshCurrentView())
+		m.applyWatchState(msg.ItemID, false)
 		cmds = append(cmds, ClearStatusCmd(3*time.Second))
 		return m, tea.Batch(cmds...)
 
@@ -562,53 +560,38 @@ func (m *Model) updateLibraryStates() {
 	m.Inspector.SetLibraryStates(m.LibraryStates)
 }
 
-// refreshCurrentView refreshes the current view
-func (m *Model) refreshCurrentView() tea.Cmd {
-	m.LibraryService.InvalidateAll()
-	m.Loading = true
+// applyWatchState patches an item's watch state in the cache and in every
+// visible column. This replaces the old invalidate-everything-and-refetch
+// approach: the UI updates instantly and no network requests are issued.
+func (m *Model) applyWatchState(itemID string, played bool) {
+	m.LibraryService.SetWatchState(itemID, played)
 
-	top := m.ColumnStack.Top()
-	if top == nil {
-		return LoadLibrariesCmd(m.LibraryService)
-	}
-
-	// Get context from column stack to reload
-	switch top.ColumnType() {
-	case components.ColumnTypeMovies:
-		if libCol := m.libraryColumn(); libCol != nil {
-			if lib := libCol.SelectedLibrary(); lib != nil {
-				return LoadMoviesCmd(m.LibraryService, lib.ID)
-			}
-		}
-	case components.ColumnTypeShows:
-		if libCol := m.libraryColumn(); libCol != nil {
-			if lib := libCol.SelectedLibrary(); lib != nil {
-				return LoadShowsCmd(m.LibraryService, lib.ID)
-			}
-		}
-	case components.ColumnTypeSeasons:
-		// Get show from parent column - needs libID for hierarchical cache
-		if showCol := m.ColumnStack.Get(m.ColumnStack.Len() - 2); showCol != nil {
-			if show := showCol.SelectedShow(); show != nil {
-				return LoadSeasonsCmd(m.LibraryService, m.currentLibID, show.ID)
-			}
-		}
-	case components.ColumnTypeEpisodes:
-		// Get season from parent column - needs full ancestry for hierarchical cache
-		if seasonCol := m.ColumnStack.Get(m.ColumnStack.Len() - 2); seasonCol != nil {
-			if season := seasonCol.SelectedSeason(); season != nil {
-				return LoadEpisodesCmd(m.LibraryService, m.currentLibID, m.currentShowID, season.ID)
-			}
-		}
-	case components.ColumnTypeMixed:
-		if libCol := m.libraryColumn(); libCol != nil {
-			if lib := libCol.SelectedLibrary(); lib != nil {
-				return LoadMixedLibraryCmd(m.LibraryService, lib.ID)
+	// Patch the item wherever a column renders it, and adjust unwatched
+	// counters on visible show/season rows if an episode flipped state.
+	var patched *domain.MediaItem
+	flipped := false
+	for i := 0; i < m.ColumnStack.Len(); i++ {
+		if col := m.ColumnStack.Get(i); col != nil {
+			if item, f := col.ApplyWatchState(itemID, played); item != nil {
+				patched = item
+				flipped = flipped || f
 			}
 		}
 	}
 
-	return LoadLibrariesCmd(m.LibraryService)
+	if flipped && patched != nil && patched.ShowID != "" {
+		delta := 1
+		if played {
+			delta = -1
+		}
+		for i := 0; i < m.ColumnStack.Len(); i++ {
+			if col := m.ColumnStack.Get(i); col != nil {
+				col.AdjustUnwatchedCounts(patched.ShowID, patched.ParentID, delta)
+			}
+		}
+	}
+
+	m.updateInspector()
 }
 
 // findLibrary finds a library by ID

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -132,7 +132,7 @@ func MarkWatchedCmd(svc *player.Service, itemID, title string) tea.Cmd {
 		if err := svc.MarkWatched(ctx, itemID); err != nil {
 			return ErrMsg{Err: err, Context: "marking as watched"}
 		}
-		return MarkWatchedMsg{Title: title}
+		return MarkWatchedMsg{ItemID: itemID, Title: title}
 	}
 }
 
@@ -145,7 +145,7 @@ func MarkUnwatchedCmd(svc *player.Service, itemID, title string) tea.Cmd {
 		if err := svc.MarkUnwatched(ctx, itemID); err != nil {
 			return ErrMsg{Err: err, Context: "marking as unwatched"}
 		}
-		return MarkUnwatchedMsg{Title: title}
+		return MarkUnwatchedMsg{ItemID: itemID, Title: title}
 	}
 }
 

--- a/internal/tui/components/list_column.go
+++ b/internal/tui/components/list_column.go
@@ -429,6 +429,48 @@ func (c *ListColumn) ReplaceItems(rawItems interface{}) {
 	}
 }
 
+// ApplyWatchState patches a media item's watch state in this column's items.
+// Returns the patched item (nil if not present) and whether the played flag
+// actually changed.
+func (c *ListColumn) ApplyWatchState(itemID string, played bool) (*domain.MediaItem, bool) {
+	for _, item := range c.items {
+		if m, ok := item.(*domain.MediaItem); ok && m.ID == itemID {
+			flipped := m.IsPlayed != played
+			m.IsPlayed = played
+			m.ViewOffset = 0
+			return m, flipped
+		}
+	}
+	return nil, false
+}
+
+// AdjustUnwatchedCounts shifts the unwatched counter on matching show and
+// season rows (used when an episode's watch state is toggled in place).
+func (c *ListColumn) AdjustUnwatchedCounts(showID, seasonID string, delta int) {
+	for _, item := range c.items {
+		switch v := item.(type) {
+		case *domain.Show:
+			if v.ID == showID {
+				v.UnwatchedCount = clampUnwatched(v.UnwatchedCount+delta, v.EpisodeCount)
+			}
+		case *domain.Season:
+			if v.ID == seasonID {
+				v.UnwatchedCount = clampUnwatched(v.UnwatchedCount+delta, v.EpisodeCount)
+			}
+		}
+	}
+}
+
+func clampUnwatched(n, max int) int {
+	if n < 0 {
+		return 0
+	}
+	if max > 0 && n > max {
+		return max
+	}
+	return n
+}
+
 // Additional methods
 
 // ColumnType returns the column's content type

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -63,12 +63,14 @@ type PlaybackStartedMsg struct {
 
 // MarkWatchedMsg signals a request to mark an item as watched
 type MarkWatchedMsg struct {
-	Title string
+	ItemID string
+	Title  string
 }
 
 // MarkUnwatchedMsg signals a request to mark an item as unwatched
 type MarkUnwatchedMsg struct {
-	Title string
+	ItemID string
+	Title  string
 }
 
 // TickMsg is a general tick message for animations


### PR DESCRIPTION
Fixes the worst daily-use interaction found in the design review (docs/design-review.md A3):

- `w`/`u` no longer call `InvalidateAll()` + refetch. The store gains `SetWatchState`, which patches the item everywhere it is cached (movie lists, episode lists, mixed content, playlist items) and adjusts season/show unwatched counters, all without touching freshness timestamps.
- Visible columns patch their rendered items through the same path, so the checkmark updates instantly with zero network traffic and the cursor stays put.
- Removes `refreshCurrentView`, whose missing playlist cases previously caused `w` on a playlist item to reset the entire app to the root and re-sync every library.

Tested: store tests (bolt + memory-only) covering episode patch, counter adjustment, idempotency, unwatch restore, playlist copy patch, and freshness preservation; full suite passes.