### PR TITLE
Support playback on WSL via Windows players and openers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Config file: `~/.config/kino/config.yaml` (created on first run).
 
 Kino auto-detects video players (mpv, VLC, IINA, Celluloid, etc.) with resume support. See `config.example.yaml` for custom player setup and all options.
 
+On WSL, Windows-side players are detected too (PotPlayer, mpv.exe, VLC), and links fall back to `wslview`/`explorer.exe` instead of `xdg-open`.
+
 ## License
 
 MIT

--- a/internal/player/launcher.go
+++ b/internal/player/launcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -40,6 +41,24 @@ var darwinPlayers = []PlayerDef{
 	{Binary: "iina", SeekFlag: "--mpv-start=%d"},
 	{Binary: "mpv", SeekFlag: "--start=%d"},
 	{Binary: "vlc", SeekFlag: "--start-time=%d"},
+}
+
+// Windows-side players reachable from WSL via interop. Probed after the
+// native Linux list so a Linux install (e.g. via WSLg) still wins.
+var wslPlayers = []PlayerDef{
+	{Binary: "PotPlayerMini64.exe", SeekFlag: "/seek=%d"},
+	{Binary: "PotPlayerMini.exe", SeekFlag: "/seek=%d"},
+	{Binary: "mpv.exe", SeekFlag: "--start=%d"},
+	{Binary: "vlc.exe", SeekFlag: "--start-time=%d"},
+}
+
+// isWSL reports whether we are running inside Windows Subsystem for Linux.
+func isWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	return err == nil && strings.Contains(strings.ToLower(string(data)), "microsoft")
 }
 
 // NewLauncher creates a new Launcher
@@ -90,6 +109,11 @@ func (l *Launcher) detectPlayer() (PlayerDef, bool) {
 		candidates = darwinPlayers
 	case "linux":
 		candidates = linuxPlayers
+		if isWSL() {
+			// WSL can execute Windows binaries via interop; a Windows-side
+			// mpv/vlc on PATH is a perfectly good player
+			candidates = append(append([]PlayerDef{}, linuxPlayers...), wslPlayers...)
+		}
 	default:
 		return PlayerDef{}, false
 	}
@@ -158,14 +182,11 @@ func (l *Launcher) launchConfigured(url string, offsetSecs int) error {
 
 // lookupSeekFlag finds the seek flag for a known player binary
 func (l *Launcher) lookupSeekFlag(binary string) string {
-	for _, p := range linuxPlayers {
-		if p.Binary == binary {
-			return p.SeekFlag
-		}
-	}
-	for _, p := range darwinPlayers {
-		if p.Binary == binary {
-			return p.SeekFlag
+	for _, table := range [][]PlayerDef{linuxPlayers, darwinPlayers, wslPlayers} {
+		for _, p := range table {
+			if p.Binary == binary {
+				return p.SeekFlag
+			}
 		}
 	}
 	return ""
@@ -193,10 +214,26 @@ func (l *Launcher) launchDefault(url string) error {
 		cmd = exec.Command("open", url)
 	default:
 		// Linux and other Unix-like systems
-		cmd = exec.Command("xdg-open", url)
+		if isWSL() {
+			// WSL distros usually have no xdg-open; hand the URL to Windows.
+			// wslview (from wslu) is purpose-built for this; explorer.exe
+			// opens the default handler and is always present.
+			for _, opener := range []string{"wslview", "explorer.exe"} {
+				if _, err := exec.LookPath(opener); err == nil {
+					cmd = exec.Command(opener, url)
+					break
+				}
+			}
+		}
+		if cmd == nil {
+			if _, err := exec.LookPath("xdg-open"); err != nil {
+				return fmt.Errorf("no media player found — install mpv (or vlc), or set player.command in config.yaml")
+			}
+			cmd = exec.Command("xdg-open", url)
+		}
 	}
 
-	l.logger.Debug("launching with system default", "os", runtime.GOOS, "url", url)
+	l.logger.Debug("launching with system default", "os", runtime.GOOS, "command", cmd.Path)
 	return cmd.Start()
 }
 

--- a/internal/player/launcher_test.go
+++ b/internal/player/launcher_test.go
@@ -1,0 +1,121 @@
+package player
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func fakeBinary(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func forceWSL(t *testing.T) {
+	t.Helper()
+	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
+}
+
+// Under WSL, a Windows-side mpv.exe on PATH (via interop) must be detected
+// when no Linux player is installed.
+func TestDetectPlayerWSLFindsExe(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	dir := t.TempDir()
+	fakeBinary(t, dir, "mpv.exe")
+	t.Setenv("PATH", dir)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	p, found := l.detectPlayer()
+	if !found {
+		t.Fatal("mpv.exe not detected under WSL")
+	}
+	if p.Binary != "mpv.exe" {
+		t.Fatalf("detected %q, want mpv.exe", p.Binary)
+	}
+	if p.SeekFlag != "--start=%d" {
+		t.Fatalf("wrong seek flag %q", p.SeekFlag)
+	}
+}
+
+// PotPlayer outranks other Windows players when several are installed.
+func TestDetectPlayerWSLPotPlayerFirst(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	dir := t.TempDir()
+	fakeBinary(t, dir, "mpv.exe")
+	fakeBinary(t, dir, "PotPlayerMini64.exe")
+	t.Setenv("PATH", dir)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	p, found := l.detectPlayer()
+	if !found || p.Binary != "PotPlayerMini64.exe" {
+		t.Fatalf("expected PotPlayer to win, got %q (found=%v)", p.Binary, found)
+	}
+	if p.SeekFlag != "/seek=%d" {
+		t.Fatalf("wrong PotPlayer seek flag %q", p.SeekFlag)
+	}
+}
+
+// A native Linux player still wins over the Windows-side one.
+func TestDetectPlayerWSLPrefersLinuxPlayer(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	dir := t.TempDir()
+	fakeBinary(t, dir, "mpv")
+	fakeBinary(t, dir, "mpv.exe")
+	t.Setenv("PATH", dir)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	p, found := l.detectPlayer()
+	if !found || p.Binary != "mpv" {
+		t.Fatalf("expected native mpv to win, got %q (found=%v)", p.Binary, found)
+	}
+}
+
+// The system-default fallback on WSL uses wslview or explorer.exe instead of
+// the usually-absent xdg-open.
+func TestLaunchDefaultWSLUsesWindowsOpener(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	dir := t.TempDir()
+	fakeBinary(t, dir, "explorer.exe")
+	t.Setenv("PATH", dir)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	if err := l.launchDefault("http://example.invalid/stream"); err != nil {
+		t.Fatalf("launchDefault failed: %v", err)
+	}
+}
+
+// With no player and no opener anywhere, the error must tell the user what
+// to do instead of surfacing a raw exec failure.
+func TestLaunchDefaultNoOpenerActionableError(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	t.Setenv("PATH", t.TempDir())
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	err := l.launchDefault("http://example.invalid/stream")
+	if err == nil {
+		t.Fatal("expected error with no opener available")
+	}
+	if !strings.Contains(err.Error(), "player.command") {
+		t.Fatalf("error not actionable: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes playback on WSL (design review C10):

- WSL detection via `WSL_DISTRO_NAME`/`WSL_INTEROP` env vars or `/proc/sys/kernel/osrelease`.
- Auto-detect now probes Windows-side players through WSL interop after the native Linux list, so a Linux mpv (WSLg) still wins: PotPlayer (`PotPlayerMini64.exe`/`PotPlayerMini.exe`, `/seek=`), `mpv.exe` (`--start=`), `vlc.exe` (`--start-time=`).
- The system-default fallback uses `wslview` (wslu) or `explorer.exe` on WSL instead of the usually-absent `xdg-open`.
- When no player or opener exists at all, the error now says what to do ("install mpv (or vlc), or set player.command in config.yaml") instead of a raw exec failure.

Verified on a real WSL2 environment matching the report (no Linux mpv, no xdg-open, `explorer.exe` reachable via interop); unit tests cover .exe detection, PotPlayer priority, Linux-player preference, the Windows-opener fallback, and the actionable error.