### PR TITLE
Use rundll32 instead of explorer.exe for WSL URL fallback

### DIFF
--- a/internal/player/launcher.go
+++ b/internal/player/launcher.go
@@ -52,6 +52,11 @@ var wslPlayers = []PlayerDef{
 	{Binary: "vlc.exe", SeekFlag: "--start-time=%d"},
 }
 
+func lookPathOK(binary string) bool {
+	_, err := exec.LookPath(binary)
+	return err == nil
+}
+
 // isWSL reports whether we are running inside Windows Subsystem for Linux.
 func isWSL() bool {
 	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
@@ -216,13 +221,17 @@ func (l *Launcher) launchDefault(url string) error {
 		// Linux and other Unix-like systems
 		if isWSL() {
 			// WSL distros usually have no xdg-open; hand the URL to Windows.
-			// wslview (from wslu) is purpose-built for this; explorer.exe
-			// opens the default handler and is always present.
-			for _, opener := range []string{"wslview", "explorer.exe"} {
-				if _, err := exec.LookPath(opener); err == nil {
-					cmd = exec.Command(opener, url)
-					break
-				}
+			// wslview (from wslu) is purpose-built for this. rundll32's
+			// FileProtocolHandler is the reliable built-in: explorer.exe
+			// chokes on URLs with query strings (?a=1&b=2) and silently
+			// opens the Documents folder instead.
+			switch {
+			case lookPathOK("wslview"):
+				cmd = exec.Command("wslview", url)
+			case lookPathOK("rundll32.exe"):
+				cmd = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", url)
+			case lookPathOK("explorer.exe"):
+				cmd = exec.Command("explorer.exe", url)
 			}
 		}
 		if cmd == nil {

--- a/internal/player/launcher_test.go
+++ b/internal/player/launcher_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func fakeBinary(t *testing.T, dir, name string) {
@@ -84,9 +85,45 @@ func TestDetectPlayerWSLPrefersLinuxPlayer(t *testing.T) {
 	}
 }
 
-// The system-default fallback on WSL uses wslview or explorer.exe instead of
-// the usually-absent xdg-open.
-func TestLaunchDefaultWSLUsesWindowsOpener(t *testing.T) {
+// The system-default fallback on WSL uses a Windows opener instead of the
+// usually-absent xdg-open, and prefers rundll32 over explorer.exe (which
+// mangles URLs containing query strings and opens Documents instead).
+func TestLaunchDefaultWSLPrefersRundll32(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := "#!/bin/sh\necho \"$@\" > " + argsFile + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "rundll32.exe"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	fakeBinary(t, dir, "explorer.exe")
+	t.Setenv("PATH", dir)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	url := "http://server:8096/stream.mkv?Static=true&api_key=x"
+	if err := l.launchDefault(url); err != nil {
+		t.Fatalf("launchDefault failed: %v", err)
+	}
+
+	// Wait for the fake opener to write its argv
+	var got []byte
+	for i := 0; i < 50; i++ {
+		if got, _ = os.ReadFile(argsFile); len(got) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	want := "url.dll,FileProtocolHandler " + url
+	if strings.TrimSpace(string(got)) != want {
+		t.Fatalf("rundll32 args = %q, want %q", strings.TrimSpace(string(got)), want)
+	}
+}
+
+// explorer.exe remains the last-resort opener when rundll32 is absent.
+func TestLaunchDefaultWSLExplorerLastResort(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("linux-only")
 	}


### PR DESCRIPTION
Follow-up to #31. Stream URLs always carry query strings (`?Static=true&api_key=...`), and `explorer.exe` silently opens the Documents folder when it can't parse an argument as a path — which is exactly what users saw when the fallback fired.

- Opener priority is now `wslview` → `rundll32.exe url.dll,FileProtocolHandler` → `explorer.exe` (last resort).
- Test pins the rundll32 argv, including a query-string URL passed through verbatim.
- Verified live on WSL2: rundll32 opens the default browser with the query string intact where explorer.exe opened Documents.