### PR TITLE
Fix correctness issues from design review

### DIFF
--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -622,10 +622,18 @@ func (c *Client) AddToPlaylist(ctx context.Context, playlistID string, itemIDs [
 	return nil
 }
 
-// RemoveFromPlaylist removes an item from a playlist
+// RemoveFromPlaylist removes an item from a playlist.
+// Jellyfin's EntryIds parameter takes the playlist-specific entry ID
+// (PlaylistItemId), not the media item's ID — passing an item ID is silently
+// ignored (204 with no change). Resolve the entry ID first.
 func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, itemID string) error {
+	entryID, err := c.resolvePlaylistEntryID(ctx, playlistID, itemID)
+	if err != nil {
+		return err
+	}
+
 	query := url.Values{}
-	query.Set("EntryIds", itemID)
+	query.Set("EntryIds", entryID)
 
 	path := fmt.Sprintf("/Playlists/%s/Items?%s", playlistID, query.Encode())
 
@@ -647,6 +655,37 @@ func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, item
 	}
 
 	return nil
+}
+
+// resolvePlaylistEntryID fetches the playlist's items and returns the
+// playlist entry ID (PlaylistItemId) for the given media item ID.
+func (c *Client) resolvePlaylistEntryID(ctx context.Context, playlistID, itemID string) (string, error) {
+	query := url.Values{}
+	query.Set("UserId", c.userID)
+
+	path := fmt.Sprintf("/Playlists/%s/Items", playlistID)
+	body, err := c.doRequest(ctx, http.MethodGet, path, query)
+	if err != nil {
+		return "", err
+	}
+
+	var resp ItemsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	for _, item := range resp.Items {
+		if item.ID == itemID {
+			if item.PlaylistItemID != "" {
+				return item.PlaylistItemID, nil
+			}
+			// Very old servers predate PlaylistItemId; fall back to the
+			// item ID, which those versions accepted
+			return itemID, nil
+		}
+	}
+
+	return "", fmt.Errorf("item %s not found in playlist %s", itemID, playlistID)
 }
 
 // DeletePlaylist deletes a playlist

--- a/internal/mediaserver/jellyfin/dto.go
+++ b/internal/mediaserver/jellyfin/dto.go
@@ -58,6 +58,7 @@ type Item struct {
 	IndexNumber        int           `json:"IndexNumber,omitempty"`        // Episode number
 	ChildCount         int           `json:"ChildCount,omitempty"`         // Number of child items (seasons for show, episodes for season)
 	RecursiveItemCount int           `json:"RecursiveItemCount,omitempty"` // Total items recursively (episodes for show)
+	PlaylistItemID     string        `json:"PlaylistItemId,omitempty"` // Per-entry ID within a playlist
 	UserData           *UserData     `json:"UserData,omitempty"`
 	MediaSources       []MediaSource `json:"MediaSources,omitempty"`
 	Container          string        `json:"Container,omitempty"`

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -111,6 +111,7 @@ type Model struct {
 	LibraryStates map[string]components.LibrarySyncState // Tracks progress per library
 	SyncingCount  int                                    // Libraries still syncing
 	MultiLibSync  bool                                   // True when syncing multiple libraries (R / startup)
+	SyncGen       int                                    // Current sync generation; messages from older generations are dropped
 
 	// Navigation plan for deep linking
 	navPlan *NavPlan
@@ -185,6 +186,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LibrariesLoadedMsg:
 		m.Libraries = msg.Libraries
 
+		// New sync generation: any still-running chains from before this
+		// reload are stale and their messages will be dropped
+		m.SyncGen++
+
 		// Initialize all states to Syncing (including playlists)
 		m.LibraryStates = make(map[string]components.LibrarySyncState)
 		for _, lib := range msg.Libraries {
@@ -205,8 +210,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Start parallel sync of ALL libraries + playlists
 		m.Loading = true
 		return m, tea.Batch(
-			SyncAllLibrariesCmd(m.LibraryService, msg.Libraries),
-			SyncPlaylistsCmd(m.PlaylistService, playlistsLibraryID),
+			SyncAllLibrariesCmd(m.LibraryService, msg.Libraries, m.SyncGen),
+			SyncPlaylistsCmd(m.PlaylistService, playlistsLibraryID, m.SyncGen),
 		)
 
 	case MoviesLoadedMsg:
@@ -384,6 +389,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case LibrarySyncProgressMsg:
+		// Drop messages from sync chains superseded by a newer library
+		// reload; without this, stale chains corrupt SyncingCount and can
+		// wedge the loading state permanently
+		if msg.Generation != m.SyncGen {
+			return m, nil
+		}
+
 		state := m.LibraryStates[msg.LibraryID]
 
 		if msg.Error != nil {
@@ -455,6 +467,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PlaylistsLoadedMsg:
 		m.Loading = false
+
+		// Validate content ID like every other load handler: a slow playlist
+		// fetch must not clobber whatever column the user navigated to since
+		if !m.validateContentID(playlistsLibraryID) {
+			return m, nil
+		}
+
 		if top := m.ColumnStack.Top(); top != nil {
 			top.ReplaceItems(msg.Playlists)
 		}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -107,7 +106,10 @@ func LoadEpisodesCmd(svc *library.Service, libID, showID, seasonID string) tea.C
 // PlayItemCmd starts playback of an item
 func PlayItemCmd(svc *player.Service, item domain.MediaItem, resume bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		// URL resolution is a network round-trip; a hung server must not
+		// wedge the command goroutine forever
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 
 		var err error
 		if resume {
@@ -170,12 +172,18 @@ func ClearLibraryStatusCmd(libID string, delay time.Duration) tea.Cmd {
 	})
 }
 
-// SyncLibraryCmd performs smart sync with streaming progress updates
-func SyncLibraryCmd(svc *library.Service, lib domain.Library) tea.Cmd {
+// SyncLibraryCmd performs smart sync with streaming progress updates.
+// The generation tags every message so the model can drop chains superseded
+// by a newer library reload (refresh-all during a running sync).
+func SyncLibraryCmd(svc *library.Service, lib domain.Library, generation int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 
 		progressCh := make(chan syncProgress, syncChannelSize)
+		// Dedicated 1-slot channel for the terminal message: progress updates
+		// may be dropped under load, but the done/error result must not be —
+		// and the buffered slot means a superseded goroutine never blocks.
+		doneCh := make(chan syncProgress, 1)
 
 		go func() {
 			defer cancel()
@@ -190,20 +198,16 @@ func SyncLibraryCmd(svc *library.Service, lib domain.Library) tea.Cmd {
 
 			result, err := svc.SyncLibrary(ctx, lib, onProgress)
 
-			// Send final message
-			select {
-			case progressCh <- syncProgress{
+			doneCh <- syncProgress{
 				loaded:    result.Count,
 				total:     result.Count,
 				done:      true,
 				fromCache: result.FromCache,
 				err:       err,
-			}:
-			default:
 			}
 		}()
 
-		return readSyncProgress(lib, progressCh)
+		return readSyncProgress(lib, generation, progressCh, doneCh)
 	}
 }
 
@@ -216,102 +220,74 @@ type syncProgress struct {
 	err       error
 }
 
-// readSyncProgress reads one message from the channel and creates a LibrarySyncProgressMsg
-func readSyncProgress(lib domain.Library, progressCh <-chan syncProgress) tea.Msg {
-	progress, ok := <-progressCh
-	if !ok {
+// readSyncProgress reads the next progress or terminal message and converts
+// it to a LibrarySyncProgressMsg. The terminal message comes from the
+// dedicated done channel, which is buffered and therefore never lost.
+func readSyncProgress(lib domain.Library, generation int, progressCh <-chan syncProgress, doneCh <-chan syncProgress) tea.Msg {
+	makeMsg := func(p syncProgress) LibrarySyncProgressMsg {
 		return LibrarySyncProgressMsg{
 			LibraryID:   lib.ID,
 			LibraryType: lib.Type,
-			Done:        true,
-			Error:       fmt.Errorf("sync cancelled"),
+			Generation:  generation,
+			Loaded:      p.loaded,
+			Total:       p.total,
+			Done:        p.done,
+			FromCache:   p.fromCache,
+			Error:       p.err,
 		}
 	}
 
-	msg := LibrarySyncProgressMsg{
-		LibraryID:   lib.ID,
-		LibraryType: lib.Type,
-		Loaded:      progress.loaded,
-		Total:       progress.total,
-		Done:        progress.done,
-		FromCache:   progress.fromCache,
-		Error:       progress.err,
+	select {
+	case p := <-doneCh:
+		return makeMsg(p)
+	case p, ok := <-progressCh:
+		if !ok {
+			// Progress channel closed: the terminal message is guaranteed to
+			// already be in doneCh (sent before the deferred close runs)
+			return makeMsg(<-doneCh)
+		}
+		msg := makeMsg(p)
+		if !p.done && p.err == nil {
+			msg.NextCmd = listenToSyncCmd(lib, generation, progressCh, doneCh)
+		}
+		return msg
 	}
-
-	if !progress.done && progress.err == nil {
-		msg.NextCmd = listenToSyncCmd(lib, progressCh)
-	}
-
-	return msg
 }
 
 // listenToSyncCmd returns a command that reads the next message from the progress channel
-func listenToSyncCmd(lib domain.Library, progressCh <-chan syncProgress) tea.Cmd {
+func listenToSyncCmd(lib domain.Library, generation int, progressCh <-chan syncProgress, doneCh <-chan syncProgress) tea.Cmd {
 	return func() tea.Msg {
-		return readSyncProgress(lib, progressCh)
+		return readSyncProgress(lib, generation, progressCh, doneCh)
 	}
 }
 
 // SyncAllLibrariesCmd syncs all libraries in parallel
-func SyncAllLibrariesCmd(svc *library.Service, libraries []domain.Library) tea.Cmd {
+func SyncAllLibrariesCmd(svc *library.Service, libraries []domain.Library, generation int) tea.Cmd {
 	teaCmds := make([]tea.Cmd, len(libraries))
 	for i, lib := range libraries {
-		teaCmds[i] = SyncLibraryCmd(svc, lib)
+		teaCmds[i] = SyncLibraryCmd(svc, lib, generation)
 	}
 	return tea.Batch(teaCmds...)
 }
 
 // SyncPlaylistsCmd syncs playlists and their items (two levels deep, like library sync).
-func SyncPlaylistsCmd(svc *playlist.Service, playlistsID string) tea.Cmd {
+func SyncPlaylistsCmd(svc *playlist.Service, playlistsID string, generation int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
 
-		progressCh := make(chan syncProgress, syncChannelSize)
+		// SyncPlaylists fetches playlists AND items for each
+		playlists, err := svc.SyncPlaylists(ctx)
 
-		go func() {
-			defer cancel()
-			defer close(progressCh)
-
-			// SyncPlaylists fetches playlists AND items for each
-			playlists, err := svc.SyncPlaylists(ctx)
-
-			// Send final message
-			select {
-			case progressCh <- syncProgress{
-				loaded:    len(playlists),
-				total:     len(playlists),
-				done:      true,
-				fromCache: false,
-				err:       err,
-			}:
-			default:
-			}
-		}()
-
-		return readPlaylistSyncProgress(playlistsID, progressCh)
-	}
-}
-
-// readPlaylistSyncProgress reads sync progress for playlists
-func readPlaylistSyncProgress(playlistsID string, progressCh <-chan syncProgress) tea.Msg {
-	progress, ok := <-progressCh
-	if !ok {
 		return LibrarySyncProgressMsg{
 			LibraryID:   playlistsID,
 			LibraryType: "playlist",
+			Generation:  generation,
+			Loaded:      len(playlists),
+			Total:       len(playlists),
 			Done:        true,
-			Error:       fmt.Errorf("sync cancelled"),
+			Error:       err,
 		}
-	}
-
-	return LibrarySyncProgressMsg{
-		LibraryID:   playlistsID,
-		LibraryType: "playlist",
-		Loaded:      progress.loaded,
-		Total:       progress.total,
-		Done:        progress.done,
-		FromCache:   progress.fromCache,
-		Error:       progress.err,
 	}
 }
 

--- a/internal/tui/components/inspector.go
+++ b/internal/tui/components/inspector.go
@@ -389,7 +389,10 @@ func (i Inspector) renderShowInspector(show domain.Show, width int) inspectorCon
 	header.WriteString("\n")
 
 	watched := show.EpisodeCount - show.UnwatchedCount
-	progress := float64(watched) / float64(show.EpisodeCount) * 100
+	progress := 0.0
+	if show.EpisodeCount > 0 {
+		progress = float64(watched) / float64(show.EpisodeCount) * 100
+	}
 	header.WriteString(styles.DimStyle.Render(fmt.Sprintf("Progress: %.0f%% (%d/%d)", progress, watched, show.EpisodeCount)))
 
 	// Body: summary
@@ -425,7 +428,10 @@ func (i Inspector) renderSeasonInspector(season domain.Season, width int) string
 
 	// Progress
 	watched := season.EpisodeCount - season.UnwatchedCount
-	progress := float64(watched) / float64(season.EpisodeCount) * 100
+	progress := 0.0
+	if season.EpisodeCount > 0 {
+		progress = float64(watched) / float64(season.EpisodeCount) * 100
+	}
 	b.WriteString(styles.DimStyle.Render(fmt.Sprintf("Progress: %.0f%% (%d/%d)", progress, watched, season.EpisodeCount)))
 
 	return b.String()

--- a/internal/tui/components/list_column.go
+++ b/internal/tui/components/list_column.go
@@ -331,18 +331,30 @@ func (c *ListColumn) SetItems(rawItems interface{}) {
 	c.clearFilter()
 	c.sortedIdx = nil
 
+	if rawItems == nil {
+		c.items = nil
+		c.sortField = SortDefault
+		c.sortDir = SortAsc
+		return
+	}
+
 	switch v := rawItems.(type) {
 	case []domain.Library:
 		c.items = WrapLibraries(v)
 		c.columnType = ColumnTypeLibraries
 	case []*domain.MediaItem:
-		// Could be movies, episodes, or playlist items - preserve column type if already set
-		if c.columnType == ColumnTypePlaylistItems {
+		// Could be movies, episodes, or playlist items. An already-typed
+		// column keeps its identity — an empty episode list must not turn
+		// the column into a movies column.
+		switch {
+		case c.columnType == ColumnTypePlaylistItems:
 			c.items = WrapPlaylistItems(v)
-		} else if len(v) > 0 && v[0].Type == domain.MediaTypeEpisode {
+		case c.columnType == ColumnTypeEpisodes:
+			c.items = WrapEpisodes(v)
+		case len(v) > 0 && v[0].Type == domain.MediaTypeEpisode:
 			c.items = WrapEpisodes(v)
 			c.columnType = ColumnTypeEpisodes
-		} else {
+		default:
 			c.items = WrapMovies(v)
 			c.columnType = ColumnTypeMovies
 		}

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -158,6 +158,9 @@ func (m Model) handleGlobalSearch() (tea.Model, tea.Cmd) {
 
 // handleDrillIn handles drilling into the selected item (l key)
 func (m Model) handleDrillIn() (tea.Model, tea.Cmd) {
+	// Manual navigation cancels any pending search-navigation plan; a stale
+	// plan resuming on a later load would teleport the user
+	m.clearNavPlan()
 	top := m.ColumnStack.Top()
 	if top == nil {
 		return m, nil
@@ -173,6 +176,7 @@ func (m Model) handleDrillIn() (tea.Model, tea.Cmd) {
 
 // handleEnter handles the enter key press
 func (m Model) handleEnter() (tea.Model, tea.Cmd) {
+	m.clearNavPlan()
 	top := m.ColumnStack.Top()
 	if top == nil {
 		return m, nil
@@ -228,6 +232,10 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		if lib == nil || lib.ID == playlistsLibraryID {
 			return m, nil
 		}
+		// Already syncing: don't start a second chain or double-count
+		if state, ok := m.LibraryStates[lib.ID]; ok && state.Status == components.StatusSyncing {
+			return m, nil
+		}
 		m.LibraryStates[lib.ID] = components.LibrarySyncState{Status: components.StatusSyncing}
 		m.SyncingCount++
 		m.Loading = true
@@ -235,7 +243,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		m.updateLibraryStates()
 		// Invalidate then sync
 		m.LibraryService.InvalidateLibrary(lib.ID)
-		return m, SyncLibraryCmd(m.LibraryService, *lib)
+		return m, SyncLibraryCmd(m.LibraryService, *lib, m.SyncGen)
 
 	case components.ColumnTypeMovies, components.ColumnTypeMixed, components.ColumnTypeShows:
 		return m.refreshLibraryContent(top)

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -89,6 +89,7 @@ type StatusMsg struct {
 type LibrarySyncProgressMsg struct {
 	LibraryID   string
 	LibraryType string
+	Generation  int // Sync generation; stale generations are dropped
 	Loaded      int
 	Total       int
 	Done        bool

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -191,6 +191,7 @@ func (m *Model) drillSelected() *drillResult {
 		if v.ID == playlistsLibraryID {
 			col := components.NewListColumn(components.ColumnTypePlaylists, "Playlists")
 			col.SetShowWatchStatus(m.UIConfig.ShowWatchStatus)
+			col.SetContentID(playlistsLibraryID)
 			m.ColumnStack.Push(col, cursor)
 			m.updateLayout()
 
@@ -360,6 +361,8 @@ func (m Model) drillIntoSelection() (tea.Model, tea.Cmd) {
 
 // handleBack handles navigation back (h/backspace)
 func (m Model) handleBack() (tea.Model, tea.Cmd) {
+	// Manual navigation cancels any pending search-navigation plan
+	m.clearNavPlan()
 	if !m.ColumnStack.CanGoBack() {
 		return m, nil
 	}


### PR DESCRIPTION
Correctness batch from docs/design-review.md (A1, A4, A5, A8, A13):

- **Jellyfin playlist-remove actually removes now**: `EntryIds` takes the playlist entry GUID, not the media item ID. Added `PlaylistItemId` to the DTO and an entry-ID resolution step, mirroring the Plex fix from bfc8685 (with an item-ID fallback for very old servers).
- **Playlists column race**: content-ID validation added (the one load handler that lacked it), so a slow playlist fetch can't clobber and retype another column.
- **Sync reliability**: terminal sync messages use a dedicated 1-slot done channel (never dropped, never blocks a superseded goroutine — the "sync cancelled" false error is gone); generation tags drop stale chains after refresh-all instead of corrupting `SyncingCount`; refreshing an already-syncing library no-ops.
- **Column identity**: empty episode lists no longer mutate an episodes column into a movies column; `SetItems(nil)` clears instead of silently doing nothing.
- **Misc**: 15s timeout on playback URL resolution; manual navigation cancels stale search nav-plans; NaN% guard in show/season inspectors.

Tested: full suite passes; drove the TUI against a fake Jellyfin server through startup sync + drill + refresh — syncs complete with checkmarks, no spurious errors.