### PR TITLE
Protect the auth token: 0600 file modes and log redaction

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,8 @@ func LoadConfig() (*Config, error) {
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(defaultConfigPath())
 	viper.AddConfigPath(".")
+	// The config file contains the server token: never world-readable
+	viper.SetConfigPermissions(0o600)
 
 	// Environment variable overrides
 	viper.SetEnvPrefix("KINO")
@@ -111,6 +113,11 @@ func LoadConfig() (*Config, error) {
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
 		// Config file not found is OK, use defaults
+	}
+
+	// Tighten pre-existing config files created with the old 0644 default
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		_ = os.Chmod(configFile, 0o600)
 	}
 
 	if err := viper.Unmarshal(cfg); err != nil {
@@ -154,6 +161,8 @@ func SaveConfig(cfg *Config) error {
 	if err := os.MkdirAll(configPath, 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
+
+	viper.SetConfigPermissions(0o600)
 
 	// Set server fields individually to ensure correct key names (snake_case)
 	viper.Set("server.type", cfg.Server.Type)
@@ -215,6 +224,7 @@ func ClearServerConfig() error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
+	viper.SetConfigPermissions(0o600)
 	configFile := filepath.Join(configPath, "config.yaml")
 	if err := viper.WriteConfigAs(configFile); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,4 +59,14 @@ func TestLoadConfigGeneratesDeviceID(t *testing.T) {
 	if !strings.Contains(string(data), "abc123") {
 		t.Fatalf("token lost when persisting device ID:\n%s", data)
 	}
+
+	// The config file contains the token: it must not be world-readable,
+	// including pre-existing files created with the old 0644 default
+	info, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("config file mode = %o, want 600", perm)
+	}
 }

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -29,11 +29,14 @@ func SetupLogger(cfg *config.LoggingConfig) (*slog.Logger, error) {
 		return nil, fmt.Errorf("failed to create log directory: %w", err)
 	}
 
-	// Open log file
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	// Open log file. 0600: log lines include server details and, at Debug
+	// level, request URLs — keep them out of reach of other local users.
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
+	// Tighten pre-existing log files created with the old 0644 default
+	_ = logFile.Chmod(0600)
 
 	// Parse log level
 	level := parseLogLevel(cfg.Level)

--- a/internal/player/launcher.go
+++ b/internal/player/launcher.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -55,6 +56,19 @@ var wslPlayers = []PlayerDef{
 func lookPathOK(binary string) bool {
 	_, err := exec.LookPath(binary)
 	return err == nil
+}
+
+// tokenParamRe matches credential query parameters in stream URLs
+var tokenParamRe = regexp.MustCompile(`(?i)((?:api_key|X-Plex-Token)=)[^&\s"']+`)
+
+// redactTokens masks credential query parameters before anything containing
+// a stream URL reaches the log file.
+func redactTokens(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = tokenParamRe.ReplaceAllString(a, "${1}REDACTED")
+	}
+	return out
 }
 
 // isWSL reports whether we are running inside Windows Subsystem for Linux.
@@ -144,7 +158,7 @@ func (l *Launcher) execPlayer(player PlayerDef, url string, offsetSecs int) erro
 
 	args = append(args, url)
 
-	l.logger.Debug("executing player", "binary", player.Binary, "args", args)
+	l.logger.Debug("executing player", "binary", player.Binary, "args", redactTokens(args))
 	cmd := exec.Command(player.Binary, args...)
 	return cmd.Start()
 }
@@ -172,7 +186,7 @@ func (l *Launcher) launchConfigured(url string, offsetSecs int) error {
 
 	args = append(args, url)
 
-	l.logger.Debug("launching configured player", "command", l.command, "args", args)
+	l.logger.Debug("launching configured player", "command", l.command, "args", redactTokens(args))
 
 	// On macOS, try 'open -a' if command not in PATH (for GUI apps)
 	if runtime.GOOS == "darwin" {
@@ -205,7 +219,7 @@ func (l *Launcher) launchMacOSApp(appName string, playerArgs []string) error {
 		cmdArgs = append(cmdArgs, playerArgs...)
 	}
 
-	l.logger.Debug("using macOS 'open -a'", "app", appName, "args", cmdArgs)
+	l.logger.Debug("using macOS 'open -a'", "app", appName, "args", redactTokens(cmdArgs))
 	cmd := exec.Command("open", cmdArgs...)
 	return cmd.Start()
 }

--- a/internal/player/launcher_test.go
+++ b/internal/player/launcher_test.go
@@ -138,6 +138,29 @@ func TestLaunchDefaultWSLExplorerLastResort(t *testing.T) {
 	}
 }
 
+// Credential query parameters must never reach the log file.
+func TestRedactTokens(t *testing.T) {
+	in := []string{
+		"--start=30",
+		"http://server:8096/Videos/1/stream.mkv?Static=true&api_key=SECRET1",
+		"http://server:32400/library/parts/2/file.mkv?X-Plex-Token=SECRET2&other=1",
+	}
+	out := redactTokens(in)
+	joined := strings.Join(out, " ")
+	if strings.Contains(joined, "SECRET1") || strings.Contains(joined, "SECRET2") {
+		t.Fatalf("token leaked: %q", joined)
+	}
+	if !strings.Contains(joined, "api_key=REDACTED") || !strings.Contains(joined, "X-Plex-Token=REDACTED") {
+		t.Fatalf("redaction markers missing: %q", joined)
+	}
+	if out[0] != "--start=30" {
+		t.Fatalf("non-URL arg mangled: %q", out[0])
+	}
+	if in[1] == out[1] {
+		t.Fatal("input not redacted")
+	}
+}
+
 // With no player and no opener anywhere, the error must tell the user what
 // to do instead of surfacing a raw exec failure.
 func TestLaunchDefaultNoOpenerActionableError(t *testing.T) {


### PR DESCRIPTION
Security batch from docs/design-review.md (B1, B2):

- `viper.SetConfigPermissions(0o600)` on every config write path, plus a chmod of pre-existing config files on load — the config file holds the Plex/Jellyfin token and was previously 0644 (readable by any local user).
- Log file opened and chmodded 0600.
- The launcher's Debug logging redacts `api_key`/`X-Plex-Token` query values from player args before they hit the log. (The token must still appear in the player's argv itself — that's how external players receive the stream URL — passing it via player-specific headers is noted in the review as a follow-up.)

Tests: config permission assertion added to the existing device-ID migration test; redaction unit test covers both token parameter forms and non-URL args.