### PR TITLE
Unify backend transport with shared error mapping and retries

### DIFF
--- a/internal/mediaserver/jellyfin/auth.go
+++ b/internal/mediaserver/jellyfin/auth.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/term"
+
+	"github.com/mmcdole/kino/internal/domain"
 )
 
 // AuthResult contains the result of a successful Jellyfin authentication
@@ -25,13 +26,6 @@ type AuthResult struct {
 	Username string
 }
 
-// Jellyfin auth errors
-var (
-	// ErrServerOffline indicates the media server is unreachable
-	ErrServerOffline = errors.New("media server is unreachable")
-	// ErrAuthFailed indicates authentication failed
-	ErrAuthFailed = errors.New("authentication failed")
-)
 
 const (
 	authTimeout = 30 * time.Second
@@ -126,7 +120,7 @@ func (f *AuthFlow) authenticate(ctx context.Context, serverURL, username, passwo
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
 		f.logger.Error("Jellyfin auth request failed", "error", err)
-		return nil, ErrServerOffline
+		return nil, fmt.Errorf("%w: %v", domain.ErrServerOffline, err)
 	}
 	defer resp.Body.Close()
 
@@ -136,7 +130,7 @@ func (f *AuthFlow) authenticate(ctx context.Context, serverURL, username, passwo
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, ErrAuthFailed
+		return nil, fmt.Errorf("%w: check username and password", domain.ErrAuthFailed)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -1,6 +1,7 @@
 package jellyfin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -48,16 +49,33 @@ func NewClient(baseURL, token, userID, deviceID string, logger *slog.Logger) *Cl
 	}
 }
 
-// doRequest performs an authenticated HTTP request to the Jellyfin API
-// Includes retry logic with exponential backoff for 5xx server errors
-func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values) ([]byte, error) {
+// do performs an authenticated HTTP request to the Jellyfin API. All error
+// mapping lives here: 401 → domain.ErrAuthFailed, transport failures →
+// domain.ErrServerOffline (wrapped with the cause), any 2xx → success.
+// Idempotent requests (retry=true) are retried on network errors and 5xx
+// responses with exponential backoff.
+func (c *Client) do(ctx context.Context, method, path string, query url.Values, jsonBody interface{}, retry bool) ([]byte, error) {
 	reqURL := fmt.Sprintf("%s%s", c.baseURL, path)
 	if query != nil {
 		reqURL = fmt.Sprintf("%s?%s", reqURL, query.Encode())
 	}
 
+	var bodyBytes []byte
+	if jsonBody != nil {
+		var err error
+		bodyBytes, err = json.Marshal(jsonBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+	}
+
+	attempts := 1
+	if retry {
+		attempts = maxRetries + 1
+	}
+
 	var lastErr error
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt < attempts; attempt++ {
 		// Check context before each attempt
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -74,21 +92,28 @@ func (c *Client) doRequest(ctx context.Context, method, path string, query url.V
 			}
 		}
 
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+		var reqBody io.Reader
+		if bodyBytes != nil {
+			reqBody = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		// Set Jellyfin auth headers
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 
-		c.logger.Debug("jellyfin request", "method", method, "url", reqURL, "attempt", attempt)
+		c.logger.Debug("jellyfin request", "method", method, "path", path, "attempt", attempt)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			c.logger.Error("jellyfin request failed", "error", err)
-			return nil, domain.ErrServerOffline
+			lastErr = fmt.Errorf("%w: %v", domain.ErrServerOffline, err)
+			c.logger.Warn("jellyfin request failed", "error", err, "method", method, "path", path, "attempt", attempt)
+			continue
 		}
 
 		body, err := io.ReadAll(resp.Body)
@@ -97,47 +122,43 @@ func (c *Client) doRequest(ctx context.Context, method, path string, query url.V
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
-		if resp.StatusCode == http.StatusUnauthorized {
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized:
 			return nil, domain.ErrAuthFailed
-		}
-
-		// Retry on 5xx server errors
-		if resp.StatusCode >= 500 && resp.StatusCode < 600 {
-			lastErr = fmt.Errorf("server error: %d - %s", resp.StatusCode, string(body))
-			queryStr := ""
-			if query != nil {
-				queryStr = query.Encode()
-			}
-			c.logger.Warn("jellyfin server error, will retry",
+		case resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("server error: %d - %s", resp.StatusCode, truncateForLog(body))
+			c.logger.Warn("jellyfin server error",
 				"status", resp.StatusCode,
-				"body", string(body),
 				"attempt", attempt,
-				"maxRetries", maxRetries,
+				"method", method,
 				"path", path,
-				"query", queryStr,
 			)
 			continue
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			c.logger.Error("jellyfin request error", "status", resp.StatusCode, "body", string(body))
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			return body, nil
+		default:
+			c.logger.Error("jellyfin request error", "status", resp.StatusCode, "path", path, "body", truncateForLog(body))
 			return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 		}
-
-		return body, nil
 	}
 
-	queryStr := ""
-	if query != nil {
-		queryStr = query.Encode()
-	}
-	c.logger.Error("jellyfin request failed after retries",
-		"error", lastErr,
-		"url", reqURL,
-		"path", path,
-		"query", queryStr,
-	)
+	c.logger.Error("jellyfin request failed", "error", lastErr, "method", method, "path", path)
 	return nil, lastErr
+}
+
+// doRequest performs an idempotent (retried) GET-style request
+func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values) ([]byte, error) {
+	return c.do(ctx, method, path, query, nil, true)
+}
+
+// truncateForLog bounds response bodies before they reach the log file
+// (a reverse proxy's 502 page can be arbitrarily large)
+func truncateForLog(body []byte) string {
+	const max = 512
+	if len(body) > max {
+		return string(body[:max]) + "...(truncated)"
+	}
+	return string(body)
 }
 
 // GetLibraries returns all available libraries (Views)
@@ -315,28 +336,17 @@ func (c *Client) GetSeasons(ctx context.Context, showID string) ([]*domain.Seaso
 	return MapSeasons(resp.Items, c.baseURL), nil
 }
 
-// GetEpisodes returns all episodes for a season
+// GetEpisodes returns all episodes for a season.
+// Queried by ParentId directly — no need for the extra round-trip that
+// looked up the season's series ID first.
 func (c *Client) GetEpisodes(ctx context.Context, seasonID string) ([]*domain.MediaItem, error) {
-	// First, get the season to find the show ID
-	seasonPath := fmt.Sprintf("/Users/%s/Items/%s", c.userID, seasonID)
-	seasonBody, err := c.doRequest(ctx, http.MethodGet, seasonPath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var season Item
-	if err := json.Unmarshal(seasonBody, &season); err != nil {
-		return nil, fmt.Errorf("failed to parse season: %w", err)
-	}
-
-	// Get episodes for this season
 	query := url.Values{}
-	query.Set("SeasonId", seasonID)
+	query.Set("ParentId", seasonID)
 	query.Set("Fields", "Overview,MediaSources,MediaStreams,DateCreated")
 	query.Set("SortBy", "IndexNumber")
 	query.Set("SortOrder", "Ascending")
 
-	path := fmt.Sprintf("/Shows/%s/Episodes", season.SeriesID)
+	path := fmt.Sprintf("/Users/%s/Items", c.userID)
 	body, err := c.doRequest(ctx, http.MethodGet, path, query)
 	if err != nil {
 		return nil, err
@@ -435,48 +445,18 @@ func (c *Client) GetMediaItem(ctx context.Context, itemID string) (*domain.Media
 // MarkPlayed marks an item as fully watched
 func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 	path := fmt.Sprintf("/Users/%s/PlayedItems/%s", c.userID, itemID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if _, err := c.do(ctx, http.MethodPost, path, nil, nil, false); err != nil {
+		return fmt.Errorf("failed to mark as played: %w", err)
 	}
-
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to mark as played: status %d", resp.StatusCode)
-	}
-
 	return nil
 }
 
 // MarkUnplayed marks an item as unwatched
 func (c *Client) MarkUnplayed(ctx context.Context, itemID string) error {
 	path := fmt.Sprintf("/Users/%s/PlayedItems/%s", c.userID, itemID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if _, err := c.do(ctx, http.MethodDelete, path, nil, nil, false); err != nil {
+		return fmt.Errorf("failed to mark as unplayed: %w", err)
 	}
-
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to mark as unplayed: status %d", resp.StatusCode)
-	}
-
 	return nil
 }
 
@@ -544,33 +524,9 @@ func (c *Client) CreatePlaylist(ctx context.Context, title string, itemIDs []str
 		reqBody["Ids"] = itemIDs
 	}
 
-	bodyBytes, err := json.Marshal(reqBody)
+	respBody, err := c.do(ctx, http.MethodPost, "/Playlists", nil, reqBody, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/Playlists",
-		strings.NewReader(string(bodyBytes)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("failed to create playlist: status %d - %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("failed to create playlist: %w", err)
 	}
 
 	// Parse the response to get the created playlist
@@ -600,25 +556,10 @@ func (c *Client) AddToPlaylist(ctx context.Context, playlistID string, itemIDs [
 	query.Set("Ids", strings.Join(itemIDs, ","))
 	query.Set("UserId", c.userID)
 
-	path := fmt.Sprintf("/Playlists/%s/Items?%s", playlistID, query.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	path := fmt.Sprintf("/Playlists/%s/Items", playlistID)
+	if _, err := c.do(ctx, http.MethodPost, path, query, nil, false); err != nil {
+		return fmt.Errorf("failed to add items to playlist: %w", err)
 	}
-
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to add items to playlist: status %d", resp.StatusCode)
-	}
-
 	return nil
 }
 
@@ -635,25 +576,10 @@ func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, item
 	query := url.Values{}
 	query.Set("EntryIds", entryID)
 
-	path := fmt.Sprintf("/Playlists/%s/Items?%s", playlistID, query.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	path := fmt.Sprintf("/Playlists/%s/Items", playlistID)
+	if _, err := c.do(ctx, http.MethodDelete, path, query, nil, false); err != nil {
+		return fmt.Errorf("failed to remove item from playlist: %w", err)
 	}
-
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to remove item from playlist: status %d", resp.StatusCode)
-	}
-
 	return nil
 }
 
@@ -691,23 +617,8 @@ func (c *Client) resolvePlaylistEntryID(ctx context.Context, playlistID, itemID 
 // DeletePlaylist deletes a playlist
 func (c *Client) DeletePlaylist(ctx context.Context, playlistID string) error {
 	path := fmt.Sprintf("/Items/%s", playlistID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if _, err := c.do(ctx, http.MethodDelete, path, nil, nil, false); err != nil {
+		return fmt.Errorf("failed to delete playlist: %w", err)
 	}
-
-	req.Header.Set("X-Emby-Authorization", buildAuthHeader(c.token, c.deviceID))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to delete playlist: status %d", resp.StatusCode)
-	}
-
 	return nil
 }

--- a/internal/mediaserver/jellyfin/client_test.go
+++ b/internal/mediaserver/jellyfin/client_test.go
@@ -1,0 +1,137 @@
+package jellyfin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mmcdole/kino/internal/domain"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, "tok", "user1", "dev1", nil)
+}
+
+// Every request path — including mutations — must map 401 to ErrAuthFailed
+// so the TUI's re-auth prompt fires.
+func TestMutations401MapToErrAuthFailed(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	ctx := context.Background()
+
+	calls := map[string]error{
+		"MarkPlayed":     c.MarkPlayed(ctx, "x"),
+		"MarkUnplayed":   c.MarkUnplayed(ctx, "x"),
+		"AddToPlaylist":  c.AddToPlaylist(ctx, "p", []string{"x"}),
+		"DeletePlaylist": c.DeletePlaylist(ctx, "p"),
+	}
+	if _, err := c.CreatePlaylist(ctx, "t", []string{"x"}); err != nil {
+		calls["CreatePlaylist"] = err
+	}
+	if err := c.RemoveFromPlaylist(ctx, "p", "x"); err != nil {
+		calls["RemoveFromPlaylist"] = err
+	}
+
+	for name, err := range calls {
+		if !errors.Is(err, domain.ErrAuthFailed) {
+			t.Errorf("%s: 401 not mapped to ErrAuthFailed, got %v", name, err)
+		}
+	}
+}
+
+// Network errors wrap ErrServerOffline while preserving the cause.
+func TestNetworkErrorWrapsServerOffline(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", "tok", "user1", "dev1", nil) // nothing listens here
+	err := c.MarkPlayed(context.Background(), "x")
+	if !errors.Is(err, domain.ErrServerOffline) {
+		t.Fatalf("network error not mapped: %v", err)
+	}
+	if err.Error() == domain.ErrServerOffline.Error() {
+		t.Fatalf("underlying cause discarded: %v", err)
+	}
+}
+
+// Idempotent requests retry on 5xx; mutations do not.
+func TestRetryPolicy(t *testing.T) {
+	var gets, posts atomic.Int32
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			gets.Add(1)
+		} else {
+			posts.Add(1)
+		}
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	ctx := context.Background()
+
+	if _, err := c.doRequest(ctx, http.MethodGet, "/Users/user1/Views", nil); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := gets.Load(); got != int32(maxRetries+1) {
+		t.Fatalf("GET attempts = %d, want %d", got, maxRetries+1)
+	}
+
+	if err := c.MarkPlayed(ctx, "x"); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("mutation attempts = %d, want 1 (no retry)", got)
+	}
+}
+
+// 204 No Content responses are success for mutations.
+func Test2xxAccepted(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	if err := c.MarkPlayed(context.Background(), "x"); err != nil {
+		t.Fatalf("204 rejected: %v", err)
+	}
+}
+
+// RemoveFromPlaylist resolves the playlist entry ID and sends it as
+// EntryIds — sending the media item ID is silently ignored by Jellyfin.
+func TestRemoveFromPlaylistUsesEntryID(t *testing.T) {
+	var deleteQuery url.Values
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Write([]byte(`{"Items":[{"Id":"item1","Name":"Ep","Type":"Episode","PlaylistItemId":"entry-guid-1"}],"TotalRecordCount":1}`))
+		case http.MethodDelete:
+			deleteQuery = r.URL.Query()
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+
+	if err := c.RemoveFromPlaylist(context.Background(), "pl1", "item1"); err != nil {
+		t.Fatal(err)
+	}
+	if got := deleteQuery.Get("EntryIds"); got != "entry-guid-1" {
+		t.Fatalf("EntryIds = %q, want entry-guid-1 (the playlist entry ID, not the item ID)", got)
+	}
+}
+
+// The auth header carries the per-install device ID on every request.
+func TestDeviceIDInAuthHeader(t *testing.T) {
+	var header string
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header = r.Header.Get("X-Emby-Authorization")
+		w.Write([]byte(`{"Items":[],"TotalRecordCount":0}`))
+	}))
+	if _, err := c.GetLibraries(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := `DeviceId="dev1"`
+	if !strings.Contains(header, want) {
+		t.Fatalf("auth header missing %s: %q", want, header)
+	}
+}

--- a/internal/mediaserver/plex/auth.go
+++ b/internal/mediaserver/plex/auth.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/mmcdole/kino/internal/domain"
 )
 
 // AuthResult contains the result of a successful Plex authentication
@@ -23,8 +25,6 @@ type AuthResult struct {
 var (
 	// ErrPINExpired indicates the authentication PIN has expired
 	ErrPINExpired = errors.New("authentication PIN has expired")
-	// ErrServerOffline indicates the media server is unreachable
-	ErrServerOffline = errors.New("media server is unreachable")
 )
 
 const (
@@ -81,7 +81,7 @@ func (a *AuthClient) GetPIN(ctx context.Context) (pin string, id int, err error)
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
 		a.logger.Error("PIN request failed", "error", err)
-		return "", 0, ErrServerOffline
+		return "", 0, fmt.Errorf("%w: %v", domain.ErrServerOffline, err)
 	}
 	defer resp.Body.Close()
 
@@ -122,7 +122,7 @@ func (a *AuthClient) CheckPIN(ctx context.Context, pinID int) (token string, cla
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
 		a.logger.Error("PIN check failed", "error", err)
-		return "", false, ErrServerOffline
+		return "", false, fmt.Errorf("%w: %v", domain.ErrServerOffline, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/mediaserver/plex/client.go
+++ b/internal/mediaserver/plex/client.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	defaultTimeout = 30 * time.Second
+	maxRetries     = 3
+	baseRetryDelay = 500 * time.Millisecond
 	userAgent      = "Kino/1.0"
 )
 
@@ -49,7 +51,7 @@ func NewClient(baseURL, token, clientID string, logger *slog.Logger) *Client {
 		logger = slog.Default()
 	}
 	return &Client{
-		baseURL:  baseURL,
+		baseURL:  strings.TrimRight(baseURL, "/"),
 		token:    token,
 		clientID: normalizeClientID(clientID),
 		httpClient: &http.Client{
@@ -91,49 +93,106 @@ func (c *Client) FetchIdentity(ctx context.Context) error {
 	return nil
 }
 
-// doRequest performs an authenticated HTTP request
-func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values) ([]byte, error) {
-	reqURL := fmt.Sprintf("%s%s", c.baseURL, path)
-	if query != nil {
-		reqURL = fmt.Sprintf("%s?%s", reqURL, query.Encode())
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
+// setHeaders applies the standard Plex request headers
+func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Plex-Token", c.token)
 	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
 	req.Header.Set("X-Plex-Product", "Kino")
 	req.Header.Set("X-Plex-Version", "1.0")
 	req.Header.Set("User-Agent", userAgent)
+}
 
-	c.logger.Debug("plex request", "method", method, "url", reqURL)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		c.logger.Error("plex request failed", "error", err)
-		return nil, domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+// do performs an authenticated HTTP request to the Plex server. All error
+// mapping lives here: 401 → domain.ErrAuthFailed, transport failures →
+// domain.ErrServerOffline (wrapped with the cause), any 2xx → success.
+// Idempotent requests (retry=true) are retried on network errors and 5xx
+// responses with exponential backoff.
+func (c *Client) do(ctx context.Context, method, path string, query url.Values, retry bool) ([]byte, error) {
+	reqURL := fmt.Sprintf("%s%s", c.baseURL, path)
+	if query != nil {
+		reqURL = fmt.Sprintf("%s?%s", reqURL, query.Encode())
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, domain.ErrAuthFailed
+	attempts := 1
+	if retry {
+		attempts = maxRetries + 1
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		c.logger.Error("plex request error", "status", resp.StatusCode, "body", string(body))
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if attempt > 0 {
+			delay := baseRetryDelay * time.Duration(1<<(attempt-1)) // 500ms, 1s, 2s
+			c.logger.Debug("retrying request", "attempt", attempt, "delay", delay, "path", path)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		c.setHeaders(req)
+
+		c.logger.Debug("plex request", "method", method, "path", path, "attempt", attempt)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("%w: %v", domain.ErrServerOffline, err)
+			c.logger.Warn("plex request failed", "error", err, "method", method, "path", path, "attempt", attempt)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, domain.ErrAuthFailed
+		case resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("server error: %d - %s", resp.StatusCode, truncateForLog(body))
+			c.logger.Warn("plex server error",
+				"status", resp.StatusCode,
+				"attempt", attempt,
+				"method", method,
+				"path", path,
+			)
+			continue
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			return body, nil
+		default:
+			c.logger.Error("plex request error", "status", resp.StatusCode, "path", path, "body", truncateForLog(body))
+			return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
 	}
 
-	return body, nil
+	c.logger.Error("plex request failed", "error", lastErr, "method", method, "path", path)
+	return nil, lastErr
+}
+
+// doRequest performs an idempotent (retried) GET-style request
+func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values) ([]byte, error) {
+	return c.do(ctx, method, path, query, true)
+}
+
+// truncateForLog bounds response bodies before they reach the log file
+// (a reverse proxy's 502 page can be arbitrarily large)
+func truncateForLog(body []byte) string {
+	const max = 512
+	if len(body) > max {
+		return string(body[:max]) + "...(truncated)"
+	}
+	return string(body)
 }
 
 // parseResponse parses a JSON response into APIResponse
@@ -311,6 +370,7 @@ func (c *Client) GetEpisodes(ctx context.Context, seasonID string) ([]*domain.Me
 func (c *Client) Search(ctx context.Context, query string) ([]*domain.MediaItem, error) {
 	params := url.Values{}
 	params.Set("query", query)
+	params.Set("limit", "50") // match the Jellyfin backend's result cap
 
 	body, err := c.doRequest(ctx, http.MethodGet, "/search", params)
 	if err != nil {
@@ -322,7 +382,7 @@ func (c *Client) Search(ctx context.Context, query string) ([]*domain.MediaItem,
 		return nil, err
 	}
 
-	return MapOnDeck(container.Metadata, c.baseURL), nil
+	return MapSearchResults(container.Metadata, c.baseURL), nil
 }
 
 // ResolvePlayableURL returns a direct playback URL for an item
@@ -382,6 +442,7 @@ func (c *Client) GetMediaItem(ctx context.Context, itemID string) (*domain.Media
 func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 	query := url.Values{}
 	query.Set("key", itemID)
+	query.Set("identifier", "com.plexapp.plugins.library") // required by some PMS versions
 
 	_, err := c.doRequest(ctx, http.MethodGet, "/:/scrobble", query)
 	return err
@@ -391,6 +452,7 @@ func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 func (c *Client) MarkUnplayed(ctx context.Context, itemID string) error {
 	query := url.Values{}
 	query.Set("key", itemID)
+	query.Set("identifier", "com.plexapp.plugins.library") // required by some PMS versions
 
 	_, err := c.doRequest(ctx, http.MethodGet, "/:/unscrobble", query)
 	return err
@@ -424,7 +486,7 @@ func (c *Client) GetPlaylistItems(ctx context.Context, playlistID string) ([]*do
 		return nil, err
 	}
 
-	return MapOnDeck(container.Metadata, c.baseURL), nil
+	return MapVideoItems(container.Metadata, c.baseURL), nil
 }
 
 // CreatePlaylist creates a new playlist with the given title and initial items.
@@ -445,35 +507,9 @@ func (c *Client) CreatePlaylist(ctx context.Context, title string, itemIDs []str
 	query.Set("smart", "0")
 	query.Set("uri", uri)
 
-	reqURL := fmt.Sprintf("%s/playlists?%s", c.baseURL, query.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	respBody, err := c.do(ctx, http.MethodPost, "/playlists", query, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
-	req.Header.Set("X-Plex-Product", "Kino")
-	req.Header.Set("X-Plex-Version", "1.0")
-	req.Header.Set("User-Agent", userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		c.logger.Error("plex create playlist failed", "error", err)
-		return nil, domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		c.logger.Error("plex create playlist error", "status", resp.StatusCode, "body", string(respBody))
-		return nil, fmt.Errorf("failed to create playlist: status %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to create playlist: %w", err)
 	}
 
 	container, err := c.parseResponse(respBody)
@@ -510,29 +546,8 @@ func (c *Client) AddToPlaylist(ctx context.Context, playlistID string, itemIDs [
 		query := url.Values{}
 		query.Set("uri", uri)
 
-		reqURL := fmt.Sprintf("%s%s?%s", c.baseURL, path, query.Encode())
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("X-Plex-Token", c.token)
-		req.Header.Set("X-Plex-Client-Identifier", c.clientID)
-		req.Header.Set("X-Plex-Product", "Kino")
-		req.Header.Set("X-Plex-Version", "1.0")
-		req.Header.Set("User-Agent", userAgent)
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			c.logger.Error("plex add to playlist failed", "error", err)
-			return domain.ErrServerOffline
-		}
-		resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-			return fmt.Errorf("failed to add item to playlist: status %d", resp.StatusCode)
+		if _, err := c.do(ctx, http.MethodPut, path, query, false); err != nil {
+			return fmt.Errorf("failed to add item to playlist: %w", err)
 		}
 	}
 
@@ -569,61 +584,17 @@ func (c *Client) RemoveFromPlaylist(ctx context.Context, playlistID string, item
 	}
 
 	deletePath := fmt.Sprintf("/playlists/%s/items/%d", playlistID, entryID)
-	reqURL := fmt.Sprintf("%s%s", c.baseURL, deletePath)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if _, err := c.do(ctx, http.MethodDelete, deletePath, nil, false); err != nil {
+		return fmt.Errorf("failed to remove item from playlist: %w", err)
 	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
-	req.Header.Set("X-Plex-Product", "Kino")
-	req.Header.Set("X-Plex-Version", "1.0")
-	req.Header.Set("User-Agent", userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		c.logger.Error("plex remove from playlist failed", "error", err)
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to remove item from playlist: status %d", resp.StatusCode)
-	}
-
 	return nil
 }
 
 // DeletePlaylist deletes a playlist
 func (c *Client) DeletePlaylist(ctx context.Context, playlistID string) error {
 	path := fmt.Sprintf("/playlists/%s", playlistID)
-	reqURL := fmt.Sprintf("%s%s", c.baseURL, path)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if _, err := c.do(ctx, http.MethodDelete, path, nil, false); err != nil {
+		return fmt.Errorf("failed to delete playlist: %w", err)
 	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Plex-Token", c.token)
-	req.Header.Set("X-Plex-Client-Identifier", c.clientID)
-	req.Header.Set("X-Plex-Product", "Kino")
-	req.Header.Set("X-Plex-Version", "1.0")
-	req.Header.Set("User-Agent", userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		c.logger.Error("plex delete playlist failed", "error", err)
-		return domain.ErrServerOffline
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to delete playlist: status %d", resp.StatusCode)
-	}
-
 	return nil
 }

--- a/internal/mediaserver/plex/client_test.go
+++ b/internal/mediaserver/plex/client_test.go
@@ -1,0 +1,132 @@
+package plex
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mmcdole/kino/internal/domain"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL, "tok", "client1", nil)
+	c.machineIdentifier = "machine1"
+	return c
+}
+
+// Every request path — including playlist mutations — must map 401 to
+// ErrAuthFailed so the TUI's re-auth prompt fires.
+func TestMutations401MapToErrAuthFailed(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	ctx := context.Background()
+
+	calls := map[string]error{
+		"MarkPlayed":     c.MarkPlayed(ctx, "1"),
+		"AddToPlaylist":  c.AddToPlaylist(ctx, "p", []string{"1"}),
+		"DeletePlaylist": c.DeletePlaylist(ctx, "p"),
+	}
+	if _, err := c.CreatePlaylist(ctx, "t", []string{"1"}); err != nil {
+		calls["CreatePlaylist"] = err
+	}
+
+	for name, err := range calls {
+		if !errors.Is(err, domain.ErrAuthFailed) {
+			t.Errorf("%s: 401 not mapped to ErrAuthFailed, got %v", name, err)
+		}
+	}
+}
+
+// Network errors wrap ErrServerOffline while preserving the cause.
+func TestNetworkErrorWrapsServerOffline(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", "tok", "client1", nil)
+	err := c.DeletePlaylist(context.Background(), "p")
+	if !errors.Is(err, domain.ErrServerOffline) {
+		t.Fatalf("network error not mapped: %v", err)
+	}
+	if err.Error() == domain.ErrServerOffline.Error() {
+		t.Fatalf("underlying cause discarded: %v", err)
+	}
+}
+
+// GETs retry on 5xx (previously Plex had no retry at all); mutations don't.
+func TestRetryPolicy(t *testing.T) {
+	var gets, deletes atomic.Int32
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			gets.Add(1)
+		} else {
+			deletes.Add(1)
+		}
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	ctx := context.Background()
+
+	if _, err := c.GetLibraries(ctx); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := gets.Load(); got != int32(maxRetries+1) {
+		t.Fatalf("GET attempts = %d, want %d", got, maxRetries+1)
+	}
+
+	if err := c.DeletePlaylist(ctx, "p"); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := deletes.Load(); got != 1 {
+		t.Fatalf("mutation attempts = %d, want 1 (no retry)", got)
+	}
+}
+
+// Scrobble endpoints must carry the identifier parameter some PMS versions
+// require.
+func TestScrobbleIdentifierParam(t *testing.T) {
+	var query url.Values
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.Query()
+		w.Write([]byte(`{}`))
+	}))
+	if err := c.MarkPlayed(context.Background(), "42"); err != nil {
+		t.Fatal(err)
+	}
+	if got := query.Get("identifier"); got != "com.plexapp.plugins.library" {
+		t.Fatalf("scrobble identifier = %q", got)
+	}
+	if got := query.Get("key"); got != "42" {
+		t.Fatalf("scrobble key = %q", got)
+	}
+}
+
+// Global search results include TV shows (parity with the Jellyfin backend).
+func TestSearchIncludesShows(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"MediaContainer":{"Metadata":[
+			{"ratingKey":"1","title":"A Movie","type":"movie"},
+			{"ratingKey":"2","title":"A Show","type":"show","year":2020}
+		]}}`))
+	}))
+
+	results, err := c.Search(context.Background(), "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2 (show dropped?)", len(results))
+	}
+	var foundShow bool
+	for _, r := range results {
+		if r.Type == domain.MediaTypeShow && r.Title == "A Show" {
+			foundShow = true
+		}
+	}
+	if !foundShow {
+		t.Fatal("show missing from search results")
+	}
+}

--- a/internal/mediaserver/plex/mapper.go
+++ b/internal/mediaserver/plex/mapper.go
@@ -244,8 +244,9 @@ func mapEpisode(m Metadata, serverURL string) domain.MediaItem {
 	return item
 }
 
-// MapOnDeck converts Plex metadata to domain media items for On Deck
-func MapOnDeck(metadata []Metadata, serverURL string) []*domain.MediaItem {
+// MapVideoItems converts Plex metadata to playable domain media items
+// (movies and episodes)
+func MapVideoItems(metadata []Metadata, serverURL string) []*domain.MediaItem {
 	items := make([]*domain.MediaItem, 0, len(metadata))
 	for _, m := range metadata {
 		switch m.Type {
@@ -255,6 +256,36 @@ func MapOnDeck(metadata []Metadata, serverURL string) []*domain.MediaItem {
 		case "episode":
 			item := mapEpisode(m, serverURL)
 			items = append(items, &item)
+		}
+	}
+	return items
+}
+
+// MapSearchResults converts Plex search metadata to domain media items.
+// Unlike MapVideoItems it includes TV shows, mirroring the Jellyfin backend
+// so global search finds shows on both.
+func MapSearchResults(metadata []Metadata, serverURL string) []*domain.MediaItem {
+	items := make([]*domain.MediaItem, 0, len(metadata))
+	for _, m := range metadata {
+		switch m.Type {
+		case "movie":
+			item := mapMovie(m, serverURL)
+			items = append(items, &item)
+		case "episode":
+			item := mapEpisode(m, serverURL)
+			items = append(items, &item)
+		case "show":
+			items = append(items, &domain.MediaItem{
+				ID:        m.RatingKey,
+				Title:     m.Title,
+				SortTitle: m.TitleSort,
+				Summary:   m.Summary,
+				Year:      m.Year,
+				AddedAt:   m.AddedAt,
+				UpdatedAt: m.UpdatedAt,
+				Rating:    m.AudienceRating,
+				Type:      domain.MediaTypeShow,
+			})
 		}
 	}
 	return items


### PR DESCRIPTION
Implements the shared-transport refactor from docs/design-review.md (A2, D7, D8, plus A10, L4, L6, and part of D10):

**The core problem:** half of each backend's methods hand-rolled HTTP requests, so the 401→`ErrAuthFailed` mapping only covered `doRequest` paths — a revoked token during any playlist mutation or Jellyfin watched-toggle showed a generic "status 401" instead of the re-auth prompt shipped in v0.4.2.

- One `do()` core per backend owns all error mapping (401, wrapped offline errors with cause, 2xx acceptance) and a unified retry policy (idempotent-only, network + 5xx, backoff). Plex gains retries it never had; Jellyfin gains network-error retries it was missing.
- All mutations converted; the copy-pasted header/boilerplate blocks are gone.
- Duplicate package-local error sentinels deleted — `errors.Is(err, domain.ErrAuthFailed)` now works across every path including setup auth flows.
- Backend parity fixes: Plex search includes shows and caps at 50 (Jellyfin behavior); scrobble carries `identifier=com.plexapp.plugins.library`; Jellyfin `GetEpisodes` is one request instead of two.
- Log hygiene: response bodies truncated before logging.
- New httptest suites for both clients (13 tests) covering the full mapping/retry/parity matrix.