### PR TITLE
Fix cache freshness model

### DIFF
--- a/cmd/kino/main.go
+++ b/cmd/kino/main.go
@@ -76,10 +76,10 @@ func run() error {
 	}
 
 	// Create store (persistence layer)
-	libraryStore, err := store.NewLibraryStore(config.DefaultCachePath(), cfg.Server.URL)
+	libraryStore, err := store.NewLibraryStore(config.DefaultCachePath(), cfg.Server.URL, cfg.Server.UserID)
 	if err != nil {
 		logger.Warn("store unavailable, continuing memory-only", "error", err)
-		libraryStore, _ = store.NewLibraryStore("", "") // Memory-only fallback
+		libraryStore, _ = store.NewLibraryStore("", "", "") // Memory-only fallback
 	}
 	defer libraryStore.Close() // Clean shutdown
 

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -3,7 +3,6 @@ package library
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/mmcdole/kino/internal/domain"
 )
@@ -98,16 +97,23 @@ func (s *Service) SyncLibrary(
 	}
 }
 
+// Fetch* fetch a library's full content and cache it. serverTS is the
+// library's UpdatedAt as known to the caller: the cache timestamp must hold
+// the server's library version, never the local clock — a local timestamp
+// compares as "newer than the server" forever and permanently disables
+// timestamp invalidation.
+
 func (s *Service) FetchMovies(
 	ctx context.Context,
 	libID string,
+	serverTS int64,
 	onProgress domain.ProgressFunc,
 ) ([]*domain.MediaItem, error) {
 	movies, err := s.fetchMoviesWithProgress(ctx, libID, onProgress)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.store.SaveMovies(libID, movies, time.Now().Unix()); err != nil {
+	if err := s.store.SaveMovies(libID, movies, serverTS); err != nil {
 		s.logger.Error("failed to save movies", "error", err, "libID", libID)
 	}
 	s.logger.Debug("fetched movies", "count", len(movies), "libID", libID)
@@ -117,13 +123,14 @@ func (s *Service) FetchMovies(
 func (s *Service) FetchShows(
 	ctx context.Context,
 	libID string,
+	serverTS int64,
 	onProgress domain.ProgressFunc,
 ) ([]*domain.Show, error) {
 	shows, err := s.fetchShowsWithProgress(ctx, libID, onProgress)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.store.SaveShows(libID, shows, time.Now().Unix()); err != nil {
+	if err := s.store.SaveShows(libID, shows, serverTS); err != nil {
 		s.logger.Error("failed to save shows", "error", err, "libID", libID)
 	}
 	s.logger.Debug("fetched shows", "count", len(shows), "libID", libID)
@@ -133,13 +140,14 @@ func (s *Service) FetchShows(
 func (s *Service) FetchMixedContent(
 	ctx context.Context,
 	libID string,
+	serverTS int64,
 	onProgress domain.ProgressFunc,
 ) ([]domain.ListItem, error) {
 	items, err := s.fetchMixedWithProgress(ctx, libID, onProgress)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.store.SaveMixedContent(libID, items, time.Now().Unix()); err != nil {
+	if err := s.store.SaveMixedContent(libID, items, serverTS); err != nil {
 		s.logger.Error("failed to save mixed content", "error", err, "libID", libID)
 	}
 	s.logger.Debug("fetched mixed content", "count", len(items), "libID", libID)
@@ -261,8 +269,12 @@ func (s *Service) fetchMixedWithProgress(
 	)
 }
 
-// fetchAll is a generic pagination helper.
-func fetchAll[T any](
+// fetchAll is a generic pagination helper. Items are deduplicated by ID:
+// offset pagination under concurrent server-side mutation can shift pages
+// and repeat items, and duplicates would otherwise be cached as truth. An
+// empty page always terminates, so a server reporting total=0 alongside a
+// non-empty page still gets fully paginated rather than truncated.
+func fetchAll[T domain.ListItem](
 	ctx context.Context,
 	fetch func(ctx context.Context, offset, limit int) ([]T, int, error),
 	chunkSize int,
@@ -273,6 +285,7 @@ func fetchAll[T any](
 	}
 
 	var all []T
+	seen := make(map[string]bool)
 	offset := 0
 
 	for {
@@ -287,13 +300,20 @@ func fetchAll[T any](
 			return nil, err
 		}
 
-		all = append(all, items...)
+		for _, item := range items {
+			id := item.GetID()
+			if id != "" && seen[id] {
+				continue
+			}
+			seen[id] = true
+			all = append(all, item)
+		}
 
 		if onProgress != nil {
 			onProgress(len(all), total)
 		}
 
-		if len(all) >= total || len(items) == 0 {
+		if len(items) == 0 || (total > 0 && len(all) >= total) {
 			break
 		}
 		offset += chunkSize

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -48,7 +48,7 @@ func (f *fakeClient) GetLibraryItemCount(ctx context.Context, libID, libType str
 
 func newTestService(t *testing.T, client *fakeClient) (*Service, domain.Store) {
 	t.Helper()
-	st, err := store.NewLibraryStore("", "") // memory-only
+	st, err := store.NewLibraryStore("", "", "") // memory-only
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,6 +127,80 @@ func TestSyncLibraryTimestampInvalidates(t *testing.T) {
 	if client.countCalls != countCallsBefore {
 		t.Fatal("count check should be skipped when timestamp already invalidates")
 	}
+}
+
+// pagedClient serves distinct pages so pagination behavior is testable.
+type pagedClient struct {
+	fakeClient
+	pages [][]*domain.MediaItem
+	total int
+}
+
+func (p *pagedClient) GetMovies(ctx context.Context, libID string, offset, limit int) ([]*domain.MediaItem, int, error) {
+	idx := offset / limit
+	if idx >= len(p.pages) {
+		return nil, p.total, nil
+	}
+	return p.pages[idx], p.total, nil
+}
+
+// Offset pagination under concurrent server mutation can repeat items across
+// pages; duplicates must not be cached as truth.
+func TestFetchMoviesDeduplicatesAcrossPages(t *testing.T) {
+	client := &pagedClient{
+		pages: [][]*domain.MediaItem{
+			{movie("a"), movie("b")},
+			{movie("b"), movie("c")}, // "b" repeated by a page shift
+		},
+		total: 4,
+	}
+	svc := NewService(client, mustStore(t), nil)
+
+	movies, err := svc.FetchMovies(context.Background(), "lib1", 100, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(movies) != 3 {
+		t.Fatalf("got %d movies, want 3 deduplicated", len(movies))
+	}
+	seen := map[string]bool{}
+	for _, m := range movies {
+		if seen[m.ID] {
+			t.Fatalf("duplicate item %s cached", m.ID)
+		}
+		seen[m.ID] = true
+	}
+}
+
+// A server reporting total=0 alongside non-empty pages must still be fully
+// paginated instead of stopping after one page.
+func TestFetchMoviesZeroTotalStillPaginates(t *testing.T) {
+	client := &pagedClient{
+		pages: [][]*domain.MediaItem{
+			{movie("a"), movie("b")},
+			{movie("c")},
+		},
+		total: 0,
+	}
+	svc := NewService(client, mustStore(t), nil)
+
+	movies, err := svc.FetchMovies(context.Background(), "lib1", 100, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(movies) != 3 {
+		t.Fatalf("got %d movies, want 3 (stopped early on total=0?)", len(movies))
+	}
+}
+
+func mustStore(t *testing.T) domain.Store {
+	t.Helper()
+	st, err := store.NewLibraryStore("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
 }
 
 // TestSyncLibraryCountCheckFailureServesCache verifies we degrade gracefully:

--- a/internal/mediaserver/jellyfin/auth.go
+++ b/internal/mediaserver/jellyfin/auth.go
@@ -26,7 +26,6 @@ type AuthResult struct {
 	Username string
 }
 
-
 const (
 	authTimeout = 30 * time.Second
 )

--- a/internal/mediaserver/jellyfin/dto.go
+++ b/internal/mediaserver/jellyfin/dto.go
@@ -58,7 +58,7 @@ type Item struct {
 	IndexNumber        int           `json:"IndexNumber,omitempty"`        // Episode number
 	ChildCount         int           `json:"ChildCount,omitempty"`         // Number of child items (seasons for show, episodes for season)
 	RecursiveItemCount int           `json:"RecursiveItemCount,omitempty"` // Total items recursively (episodes for show)
-	PlaylistItemID     string        `json:"PlaylistItemId,omitempty"` // Per-entry ID within a playlist
+	PlaylistItemID     string        `json:"PlaylistItemId,omitempty"`     // Per-entry ID within a playlist
 	UserData           *UserData     `json:"UserData,omitempty"`
 	MediaSources       []MediaSource `json:"MediaSources,omitempty"`
 	Container          string        `json:"Container,omitempty"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,7 +43,11 @@ type LibraryStore struct {
 	cache map[string][]byte
 }
 
-func NewLibraryStore(baseCacheDir, serverURL string) (*LibraryStore, error) {
+// NewLibraryStore opens (or creates) the cache for one server+user pair.
+// The user ID is part of the cache key: watch status, view offsets, and
+// playlists are per-user, so two accounts on the same server must not share
+// a cache. (Plex configs have no user ID; those stay keyed by URL alone.)
+func NewLibraryStore(baseCacheDir, serverURL, userID string) (*LibraryStore, error) {
 	if baseCacheDir == "" {
 		// Memory-only mode (no persistence)
 		return &LibraryStore{cache: make(map[string][]byte)}, nil
@@ -51,7 +55,7 @@ func NewLibraryStore(baseCacheDir, serverURL string) (*LibraryStore, error) {
 
 	dir := baseCacheDir
 	if serverURL != "" {
-		dir = filepath.Join(baseCacheDir, hashServerURL(serverURL))
+		dir = filepath.Join(baseCacheDir, hashServerURL(serverURL+"|"+userID))
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
@@ -291,16 +295,50 @@ func (s *LibraryStore) SaveMixedContent(libID string, items []domain.ListItem, s
 
 // === Seasons (hierarchical key: lib:{libID}:show:{showID}) ===
 
+// tvCacheTTL bounds staleness of the TV hierarchy caches. Unlike libraries
+// (which have a server timestamp plus an item-count check), seasons and
+// episodes expose no server-side freshness signal at all, so without a TTL
+// they would be served stale forever — new episodes never appearing until a
+// manual refresh.
+const tvCacheTTL = 6 * time.Hour
+
+// timestamped wraps hierarchical cache payloads with their fetch time.
+// Pre-TTL cache entries fail to decode into this wrapper and simply read as
+// cache misses.
+type timestamped struct {
+	FetchedAt int64           `json:"fetched_at"`
+	Data      json.RawMessage `json:"data"`
+}
+
+func (s *LibraryStore) getWithTTL(bucket []byte, key string, dest interface{}) bool {
+	var wrapper timestamped
+	if !s.get(bucket, key, &wrapper) {
+		return false
+	}
+	if time.Now().Unix()-wrapper.FetchedAt > int64(tvCacheTTL.Seconds()) {
+		return false
+	}
+	return json.Unmarshal(wrapper.Data, dest) == nil
+}
+
+func (s *LibraryStore) setWithTTL(bucket []byte, key string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return s.set(bucket, key, timestamped{FetchedAt: time.Now().Unix(), Data: data})
+}
+
 func (s *LibraryStore) GetSeasons(libID, showID string) ([]*domain.Season, bool) {
 	var seasons []*domain.Season
 	key := fmt.Sprintf("lib:%s:show:%s", libID, showID)
-	ok := s.get(bucketSeasons, key, &seasons)
+	ok := s.getWithTTL(bucketSeasons, key, &seasons)
 	return seasons, ok
 }
 
 func (s *LibraryStore) SaveSeasons(libID, showID string, seasons []*domain.Season) error {
 	key := fmt.Sprintf("lib:%s:show:%s", libID, showID)
-	return s.set(bucketSeasons, key, seasons)
+	return s.setWithTTL(bucketSeasons, key, seasons)
 }
 
 // === Episodes (hierarchical key: lib:{libID}:show:{showID}:season:{seasonID}) ===
@@ -308,13 +346,13 @@ func (s *LibraryStore) SaveSeasons(libID, showID string, seasons []*domain.Seaso
 func (s *LibraryStore) GetEpisodes(libID, showID, seasonID string) ([]*domain.MediaItem, bool) {
 	var episodes []*domain.MediaItem
 	key := fmt.Sprintf("lib:%s:show:%s:season:%s", libID, showID, seasonID)
-	ok := s.get(bucketEpisodes, key, &episodes)
+	ok := s.getWithTTL(bucketEpisodes, key, &episodes)
 	return episodes, ok
 }
 
 func (s *LibraryStore) SaveEpisodes(libID, showID, seasonID string, episodes []*domain.MediaItem) error {
 	key := fmt.Sprintf("lib:%s:show:%s:season:%s", libID, showID, seasonID)
-	return s.set(bucketEpisodes, key, episodes)
+	return s.setWithTTL(bucketEpisodes, key, episodes)
 }
 
 // === Validation ===
@@ -376,7 +414,7 @@ func (s *LibraryStore) SetWatchState(itemID string, played bool) {
 		return out
 	}
 
-	s.updateEach(bucketEpisodes, nil, patchItemList)
+	s.updateEach(bucketEpisodes, nil, wrapped(patchItemList))
 	s.updateEach(bucketContent, keySuffix(":movies"), patchItemList)
 	s.updateEach(bucketPlaylists, keyPrefix("items:"), patchItemList)
 	s.updateEach(bucketContent, keySuffix(":mixed"), func(key string, data []byte) []byte {
@@ -409,7 +447,7 @@ func (s *LibraryStore) SetWatchState(itemID string, played bool) {
 		delta = -1
 	}
 
-	s.updateEach(bucketSeasons, nil, func(key string, data []byte) []byte {
+	s.updateEach(bucketSeasons, nil, wrapped(func(key string, data []byte) []byte {
 		var seasons []*domain.Season
 		if json.Unmarshal(data, &seasons) != nil {
 			return nil
@@ -429,7 +467,7 @@ func (s *LibraryStore) SetWatchState(itemID string, played bool) {
 			return nil
 		}
 		return out
-	})
+	}))
 
 	adjustShow := func(show *domain.Show) bool {
 		if show == nil || show.ID != showID {
@@ -492,6 +530,27 @@ func clampCount(n, max int) int {
 
 func keySuffix(suffix string) func(string) bool {
 	return func(k string) bool { return strings.HasSuffix(k, suffix) }
+}
+
+// wrapped adapts a payload transform to values stored inside the timestamped
+// TTL wrapper (seasons/episodes), preserving the original fetch time.
+func wrapped(transform func(key string, data []byte) []byte) func(key string, data []byte) []byte {
+	return func(key string, data []byte) []byte {
+		var w timestamped
+		if json.Unmarshal(data, &w) != nil || w.Data == nil {
+			return nil
+		}
+		newData := transform(key, w.Data)
+		if newData == nil {
+			return nil
+		}
+		w.Data = newData
+		out, err := json.Marshal(w)
+		if err != nil {
+			return nil
+		}
+		return out
+	}
 }
 
 func keyPrefix(prefix string) func(string) bool {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,14 +1,16 @@
 package store
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/mmcdole/kino/internal/domain"
 )
 
 func seedStore(t *testing.T, dir string) *LibraryStore {
 	t.Helper()
-	s, err := NewLibraryStore(dir, "http://test")
+	s, err := NewLibraryStore(dir, "http://test", "user1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,6 +102,42 @@ func testWatchState(t *testing.T, s *LibraryStore) {
 
 func TestSetWatchStateBolt(t *testing.T) {
 	testWatchState(t, seedStore(t, t.TempDir()))
+}
+
+// Seasons/episodes have no server-side freshness signal; entries past the
+// TTL must read as cache misses so drill-downs refetch.
+func TestTVCacheTTL(t *testing.T) {
+	s := seedStore(t, "")
+
+	// Fresh write: served
+	if _, ok := s.GetEpisodes("lib2", "show1", "season1"); !ok {
+		t.Fatal("fresh episodes not served")
+	}
+	if _, ok := s.GetSeasons("lib2", "show1"); !ok {
+		t.Fatal("fresh seasons not served")
+	}
+
+	// Force-expire the episodes entry by rewriting its wrapper timestamp
+	data, _ := json.Marshal([]*domain.MediaItem{{ID: "ep1"}})
+	expired := timestamped{
+		FetchedAt: time.Now().Add(-tvCacheTTL - time.Hour).Unix(),
+		Data:      data,
+	}
+	if err := s.set(bucketEpisodes, "lib:lib2:show:show1:season:season1", expired); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := s.GetEpisodes("lib2", "show1", "season1"); ok {
+		t.Fatal("expired episodes served from cache")
+	}
+
+	// Pre-TTL cache format (bare array, no wrapper) reads as a miss
+	if err := s.set(bucketEpisodes, "lib:l:show:s:season:x", []*domain.MediaItem{{ID: "old"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.GetEpisodes("l", "s", "x"); ok {
+		t.Fatal("legacy unwrapped entry served instead of miss")
+	}
 }
 
 func TestSetWatchStateMemoryOnly(t *testing.T) {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -34,44 +34,44 @@ func LoadLibrariesCmd(svc *library.Service) tea.Cmd {
 }
 
 // LoadMoviesCmd loads movies from a library
-func LoadMoviesCmd(svc *library.Service, libID string) tea.Cmd {
+func LoadMoviesCmd(svc *library.Service, lib domain.Library) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		movies, err := svc.FetchMovies(ctx, libID, nil)
+		movies, err := svc.FetchMovies(ctx, lib.ID, lib.UpdatedAt, nil)
 		if err != nil {
 			return ErrMsg{Err: err, Context: "loading movies"}
 		}
-		return MoviesLoadedMsg{Movies: movies, LibraryID: libID}
+		return MoviesLoadedMsg{Movies: movies, LibraryID: lib.ID}
 	}
 }
 
 // LoadShowsCmd loads TV shows from a library
-func LoadShowsCmd(svc *library.Service, libID string) tea.Cmd {
+func LoadShowsCmd(svc *library.Service, lib domain.Library) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		shows, err := svc.FetchShows(ctx, libID, nil)
+		shows, err := svc.FetchShows(ctx, lib.ID, lib.UpdatedAt, nil)
 		if err != nil {
 			return ErrMsg{Err: err, Context: "loading shows"}
 		}
-		return ShowsLoadedMsg{Shows: shows, LibraryID: libID}
+		return ShowsLoadedMsg{Shows: shows, LibraryID: lib.ID}
 	}
 }
 
 // LoadMixedLibraryCmd loads content (movies AND shows) from a mixed library
-func LoadMixedLibraryCmd(svc *library.Service, libID string) tea.Cmd {
+func LoadMixedLibraryCmd(svc *library.Service, lib domain.Library) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		items, err := svc.FetchMixedContent(ctx, libID, nil)
+		items, err := svc.FetchMixedContent(ctx, lib.ID, lib.UpdatedAt, nil)
 		if err != nil {
 			return ErrMsg{Err: err, Context: "loading library content"}
 		}
-		return MixedLibraryLoadedMsg{Items: items, LibraryID: libID}
+		return MixedLibraryLoadedMsg{Items: items, LibraryID: lib.ID}
 	}
 }
 

--- a/internal/tui/components/list_item.go
+++ b/internal/tui/components/list_item.go
@@ -68,4 +68,3 @@ func WrapPlaylistItems(items []*domain.MediaItem) []domain.ListItem {
 	}
 	return result
 }
-

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -305,11 +305,11 @@ func (m Model) refreshLibraryContent(top *components.ListColumn) (Model, tea.Cmd
 
 	switch lib.Type {
 	case "movie":
-		return m, LoadMoviesCmd(m.LibraryService, lib.ID)
+		return m, LoadMoviesCmd(m.LibraryService, *lib)
 	case "show":
-		return m, LoadShowsCmd(m.LibraryService, lib.ID)
+		return m, LoadShowsCmd(m.LibraryService, *lib)
 	default:
-		return m, LoadMixedLibraryCmd(m.LibraryService, lib.ID)
+		return m, LoadMixedLibraryCmd(m.LibraryService, *lib)
 	}
 }
 

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -126,7 +126,7 @@ func (m *Model) navigateToMixedLibraryItem(lib *domain.Library, targets []NavTar
 	m.ColumnStack.Push(mixedCol, 0)
 	m.Loading = true
 	m.updateLayout()
-	return LoadMixedLibraryCmd(m.LibraryService, lib.ID)
+	return LoadMixedLibraryCmd(m.LibraryService, *lib)
 }
 
 // NavigationContext contains information needed to navigate to an item
@@ -229,7 +229,7 @@ func (m *Model) drillSelected() *drillResult {
 					}
 					return nil
 				},
-				loadCmd: LoadMoviesCmd(m.LibraryService, v.ID),
+				loadCmd: LoadMoviesCmd(m.LibraryService, v),
 			}
 		case "show":
 			spec = columnLoadSpec{
@@ -243,7 +243,7 @@ func (m *Model) drillSelected() *drillResult {
 					}
 					return nil
 				},
-				loadCmd: LoadShowsCmd(m.LibraryService, v.ID),
+				loadCmd: LoadShowsCmd(m.LibraryService, v),
 			}
 		case "mixed":
 			spec = columnLoadSpec{
@@ -257,7 +257,7 @@ func (m *Model) drillSelected() *drillResult {
 					}
 					return nil
 				},
-				loadCmd: LoadMixedLibraryCmd(m.LibraryService, v.ID),
+				loadCmd: LoadMixedLibraryCmd(m.LibraryService, v),
 			}
 		default:
 			// Unknown library type - treat as mixed
@@ -272,7 +272,7 @@ func (m *Model) drillSelected() *drillResult {
 					}
 					return nil
 				},
-				loadCmd: LoadMixedLibraryCmd(m.LibraryService, v.ID),
+				loadCmd: LoadMixedLibraryCmd(m.LibraryService, v),
 			}
 		}
 		return m.pushAndLoadColumn(spec, cursor)
@@ -537,7 +537,7 @@ func (m *Model) navigateToTypedLibraryItem(lib *domain.Library, navCtx Navigatio
 				}
 				return nil
 			},
-			loadCmd: LoadMoviesCmd(m.LibraryService, navCtx.LibraryID),
+			loadCmd: LoadMoviesCmd(m.LibraryService, *lib),
 		}
 	} else {
 		// Shows and episodes both start from the shows column
@@ -558,7 +558,7 @@ func (m *Model) navigateToTypedLibraryItem(lib *domain.Library, navCtx Navigatio
 				}
 				return nil
 			},
-			loadCmd: LoadShowsCmd(m.LibraryService, navCtx.LibraryID),
+			loadCmd: LoadShowsCmd(m.LibraryService, *lib),
 		}
 	}
 


### PR DESCRIPTION
Freshness fixes from docs/design-review.md (A6, A7, A13-pagination, M7):

- **Local-clock poisoning (A6)**: `FetchMovies/FetchShows/FetchMixedContent` saved `time.Now()` as the "server timestamp", permanently defeating `IsValid` after any drill-down (local epoch > Plex's `contentChangedAt` counter or Jellyfin's `DateCreated`, forever). They now take the library's `UpdatedAt` plumbed from the caller, which always has the `domain.Library` in hand.
- **TV hierarchy TTL (A7)**: seasons/episodes now cache inside a `{fetched_at, data}` wrapper with a 6-hour TTL. No server-side signal exists for their freshness, so previously they were fresh forever. Legacy unwrapped entries decode as misses (clean migration). `SetWatchState`'s in-place patching unwraps/rewraps transparently.
- **Pagination hardening**: `fetchAll` dedupes by item ID and treats `total=0` with non-empty pages as unknown-total (paginate until empty) rather than truncating after one page.
- **Per-user cache (M7)**: cache directory hash now includes the user ID — two Jellyfin accounts on one server no longer share watch state and playlists. Existing caches re-sync once under the new key.

New tests: TTL expiry + legacy-format migration, page-shift dedupe, zero-total pagination. Full suite passes.