### PR TITLE
Keep navigation position through refresh-all

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -198,21 +198,51 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.LibraryStates[playlistsLibraryID] = components.LibrarySyncState{Status: components.StatusSyncing}
 		m.SyncingCount = len(msg.Libraries) + 1 // +1 for playlists
 		m.MultiLibSync = true
+		m.Inspector.SetLibraryStates(m.LibraryStates)
+		m.Loading = true
 
-		// Create the library column as the root
+		syncCmds := []tea.Cmd{
+			SyncAllLibrariesCmd(m.LibraryService, msg.Libraries, m.SyncGen),
+			SyncPlaylistsCmd(m.PlaylistService, playlistsLibraryID, m.SyncGen),
+		}
+
+		// Refresh-all with the user somewhere deeper: keep their position.
+		// Update the root column in place and reload the top column's
+		// content in the background instead of resetting to the root.
+		if msg.Refresh && m.ColumnStack.Len() > 1 {
+			libCol := m.libraryColumn()
+			var drilledID string
+			if libCol != nil {
+				if sel := libCol.SelectedLibrary(); sel != nil {
+					drilledID = sel.ID
+				}
+				libCol.ReplaceItems(m.allLibraryEntries())
+				libCol.SetLibraryStates(m.LibraryStates)
+			}
+
+			// The library the user is inside may have been removed
+			// server-side — that's the one case where resetting is the
+			// only sane answer
+			if drilledID != "" && drilledID != playlistsLibraryID && m.findLibrary(drilledID) == nil {
+				m.StatusMsg = "Library no longer exists on server"
+				m.StatusIsErr = true
+				syncCmds = append(syncCmds, ClearStatusCmd(5*time.Second))
+			} else {
+				if reload := m.reloadTopColumnCmd(); reload != nil {
+					syncCmds = append(syncCmds, reload)
+				}
+				return m, tea.Batch(syncCmds...)
+			}
+		}
+
+		// Initial load (or unrecoverable refresh): build the root column
 		libCol := components.NewLibraryColumn(m.allLibraryEntries())
 		libCol.SetLibraryStates(m.LibraryStates)
 		libCol.SetShowWatchStatus(m.UIConfig.ShowWatchStatus)
 		libCol.SetShowLibraryCounts(m.UIConfig.ShowLibraryCounts)
-		m.Inspector.SetLibraryStates(m.LibraryStates)
 		m.ColumnStack.Reset(libCol)
 
-		// Start parallel sync of ALL libraries + playlists
-		m.Loading = true
-		return m, tea.Batch(
-			SyncAllLibrariesCmd(m.LibraryService, msg.Libraries, m.SyncGen),
-			SyncPlaylistsCmd(m.PlaylistService, playlistsLibraryID, m.SyncGen),
-		)
+		return m, tea.Batch(syncCmds...)
 
 	case MoviesLoadedMsg:
 		m.Loading = false
@@ -577,6 +607,58 @@ func (m *Model) updateLibraryStates() {
 		libCol.SetLibraryStates(m.LibraryStates)
 	}
 	m.Inspector.SetLibraryStates(m.LibraryStates)
+}
+
+// reloadTopColumnCmd returns a command reloading the top column's content
+// from the server, landing via ReplaceItems so the cursor and view state
+// survive. Used by refresh-all to freshen the visible view without
+// resetting navigation. Returns nil at the root (updated in place).
+func (m *Model) reloadTopColumnCmd() tea.Cmd {
+	top := m.ColumnStack.Top()
+	if top == nil {
+		return nil
+	}
+
+	lib := m.findLibrary(m.currentLibID)
+
+	switch top.ColumnType() {
+	case components.ColumnTypeMovies:
+		if lib != nil {
+			top.SetRefreshing(true)
+			return LoadMoviesCmd(m.LibraryService, *lib)
+		}
+	case components.ColumnTypeShows:
+		if lib != nil {
+			top.SetRefreshing(true)
+			return LoadShowsCmd(m.LibraryService, *lib)
+		}
+	case components.ColumnTypeMixed:
+		if lib != nil {
+			top.SetRefreshing(true)
+			return LoadMixedLibraryCmd(m.LibraryService, *lib)
+		}
+	case components.ColumnTypeSeasons:
+		if m.currentShowID != "" {
+			top.SetRefreshing(true)
+			return LoadSeasonsCmd(m.LibraryService, m.currentLibID, m.currentShowID)
+		}
+	case components.ColumnTypeEpisodes:
+		if seasonCol := m.ColumnStack.Get(m.ColumnStack.Len() - 2); seasonCol != nil {
+			if season := seasonCol.SelectedSeason(); season != nil {
+				top.SetRefreshing(true)
+				return LoadEpisodesCmd(m.LibraryService, m.currentLibID, m.currentShowID, season.ID)
+			}
+		}
+	case components.ColumnTypePlaylists:
+		top.SetRefreshing(true)
+		return LoadPlaylistsCmd(m.PlaylistService)
+	case components.ColumnTypePlaylistItems:
+		if m.currentPlaylistID != "" {
+			top.SetRefreshing(true)
+			return LoadPlaylistItemsCmd(m.PlaylistService, m.currentPlaylistID)
+		}
+	}
+	return nil
 }
 
 // applyWatchState patches an item's watch state in the cache and in every

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -20,6 +20,16 @@ const syncChannelSize = 100
 
 // LoadLibrariesCmd loads all available libraries
 func LoadLibrariesCmd(svc *library.Service) tea.Cmd {
+	return loadLibrariesCmd(svc, false)
+}
+
+// RefreshLibrariesCmd reloads libraries for refresh-all, signaling the
+// handler to preserve the navigation stack where possible
+func RefreshLibrariesCmd(svc *library.Service) tea.Cmd {
+	return loadLibrariesCmd(svc, true)
+}
+
+func loadLibrariesCmd(svc *library.Service, refresh bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -29,7 +39,7 @@ func LoadLibrariesCmd(svc *library.Service) tea.Cmd {
 			slog.Error("failed to load libraries", "error", err)
 			return ErrMsg{Err: err, Context: "loading libraries"}
 		}
-		return LibrariesLoadedMsg{Libraries: libraries}
+		return LibrariesLoadedMsg{Libraries: libraries, Refresh: refresh}
 	}
 }
 

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -313,16 +313,16 @@ func (m Model) refreshLibraryContent(top *components.ListColumn) (Model, tea.Cmd
 	}
 }
 
-// handleRefreshAll refreshes all libraries and resets to library view
+// handleRefreshAll refreshes all libraries. Unlike before, the navigation
+// stack is preserved: the LibrariesLoadedMsg handler updates the root column
+// in place and reloads the visible view, only resetting when the library the
+// user is inside no longer exists.
 func (m Model) handleRefreshAll() (tea.Model, tea.Cmd) {
 	m.Loading = true
 
-	// Invalidate all cached data, then re-fetch libraries from the server.
-	// This goes through LoadLibrariesCmd -> LibrariesLoadedMsg which rebuilds
-	// the full library list and triggers SyncAllLibrariesCmd with fresh data.
 	m.LibraryService.InvalidateAll()
 	m.PlaylistService.InvalidatePlaylists()
-	return m, LoadLibrariesCmd(m.LibraryService)
+	return m, RefreshLibrariesCmd(m.LibraryService)
 }
 
 // handleMarkWatched marks the selected item as watched

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -24,6 +24,7 @@ func (e ErrMsg) Error() string {
 // LibrariesLoadedMsg signals that libraries have been loaded
 type LibrariesLoadedMsg struct {
 	Libraries []domain.Library
+	Refresh   bool // true for refresh-all: keep the navigation stack if possible
 }
 
 // MoviesLoadedMsg signals that movies have been loaded


### PR DESCRIPTION
Implements C9 from docs/design-review.md (agreed follow-up to #24):

- `LibrariesLoadedMsg` gains a `Refresh` flag; `R` uses `RefreshLibrariesCmd` while startup/logout keep the reset path.
- On refresh with the user drilled in: the root libraries column updates in place (`ReplaceItems`, selection preserved), all libraries resync in the background exactly as before, and the top column's content reloads from the server — landing via `ReplaceItems`, so the cursor survives.
- If the library the user is standing in was deleted server-side, the stack resets to root with a "Library no longer exists on server" status — the one case where resetting is the only sane behavior.
- Deeper parent columns keep their (possibly stale) items as context; caches were invalidated, so any navigation refetches fresh data.

Verified end-to-end against a fake Jellyfin server: drill into a library, move the cursor, press `R` — the two-column layout, the movies column, and its rows all remain on screen through the resync; no reset to root.