### PR TITLE
UX polish: confirmations, feedback, and consistent key semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,24 @@ You'll be prompted to enter your server URL. Kino automatically detects whether 
 |-----|--------|
 | `↑` `↓` `j` `k` | Navigate up/down |
 | `←` `→` `h` `l` | Navigate left/right (columns) |
-| `Enter` | Play/Select item |
+| `Backspace` | Back |
+| `Enter` | Play / drill in |
+| `p` | Play from start |
+| `w` / `u` | Mark watched / unwatched |
 | `Space` | Manage playlists |
+| `x` | Delete playlist / remove item (in playlists) |
 | `f` | Global search |
 | `/` | Local filter (current column) |
 | `s` | Sort options |
 | `i` | Toggle inspector panel |
-| `r` | Refresh current library |
+| `r` | Refresh current view |
 | `R` | Refresh all libraries |
-| `g` | Jump to top |
-| `G` | Jump to bottom |
-| `Ctrl+u` / `Ctrl+d` | Page up/down |
+| `g` / `G` | Jump to top / bottom |
+| `PgUp` / `PgDn` | Page up/down |
+| `Ctrl+u` / `Ctrl+d` | Half page up/down |
 | `?` | Show help |
-| `q` | Quit/Back |
+| `L` | Logout |
+| `q` / `Ctrl+c` | Quit |
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/viper v1.21.0
 	go.etcd.io/bbolt v1.4.3
@@ -25,7 +26,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -27,6 +27,7 @@ const (
 	StateBrowsing ApplicationState = iota
 	StateHelp
 	StateConfirmLogout
+	StateConfirmDeletePlaylist
 )
 
 // Layout proportions for Miller Columns
@@ -118,6 +119,10 @@ type Model struct {
 
 	// Playlist navigation context (when viewing playlist items)
 	currentPlaylistID string
+
+	// Pending playlist deletion awaiting confirmation
+	pendingDeletePlaylistID   string
+	pendingDeletePlaylistName string
 
 	// Navigation context for hierarchical cache keys (cascade invalidation)
 	currentLibID  string // Set when entering a library
@@ -375,7 +380,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PlaybackStartedMsg:
 		m.StatusMsg = "Launched: " + msg.Item.Title
-		return m, nil
+		return m, ClearStatusCmd(3 * time.Second)
 
 	case MarkWatchedMsg:
 		m.StatusMsg = "Marked watched: " + msg.Title
@@ -393,9 +398,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.clearNavPlan()
 		m.StatusIsErr = true
 		m.Loading = false
-		// A failed refresh must not leave the column spinner running
+		// A failed refresh must not leave the column spinner running, and a
+		// failed initial load must show a retry hint, not spin forever
 		if top := m.ColumnStack.Top(); top != nil {
 			top.SetRefreshing(false)
+			if top.IsLoading() {
+				top.SetLoadFailed()
+			}
 		}
 		if errors.Is(msg.Err, domain.ErrAuthFailed) {
 			// Actionable, persistent message: the token was revoked/expired
@@ -526,6 +535,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case PlaylistModalDataMsg:
+		m.StatusMsg = "" // clear the "Loading playlists..." pending status
 		m.PlaylistModal.Show(msg.Playlists, msg.Membership, msg.Item)
 		m.PlaylistModal.SetSize(m.Width, m.Height)
 		return m, nil

--- a/internal/tui/components/keys.go
+++ b/internal/tui/components/keys.go
@@ -159,9 +159,12 @@ func DefaultSortModalKeyMap() SortModalKeyMap {
 			key.WithKeys("j", "down"),
 			key.WithHelp("j/↓", "down"),
 		),
+		// "h" deliberately excluded from Left: everywhere else in the app
+		// h means back/cancel, so here it closes the modal instead of
+		// silently applying an ascending sort
 		Left: key.NewBinding(
-			key.WithKeys("h", "left"),
-			key.WithHelp("←/h", "asc"),
+			key.WithKeys("left"),
+			key.WithHelp("←", "asc"),
 		),
 		Right: key.NewBinding(
 			key.WithKeys("l", "right"),
@@ -176,7 +179,7 @@ func DefaultSortModalKeyMap() SortModalKeyMap {
 			key.WithHelp("esc", "cancel"),
 		),
 		Close: key.NewBinding(
-			key.WithKeys("s"),
+			key.WithKeys("s", "h"),
 			key.WithHelp("s", "close"),
 		),
 	}

--- a/internal/tui/components/list_column.go
+++ b/internal/tui/components/list_column.go
@@ -49,6 +49,7 @@ type ListColumn struct {
 	// Loading state
 	loading      bool
 	refreshing   bool // background refresh in progress; items stay visible
+	loadFailed   bool // last load errored; renders a retry hint instead of a spinner
 	spinnerFrame int
 
 	// Library sync states (for library column)
@@ -320,12 +321,20 @@ func (c *ListColumn) SetRefreshing(refreshing bool) {
 	c.refreshing = refreshing
 }
 
+// SetLoadFailed marks the column's load as failed, replacing the infinite
+// spinner with an actionable retry hint.
+func (c *ListColumn) SetLoadFailed() {
+	c.loading = false
+	c.loadFailed = true
+}
+
 func (c *ListColumn) IsRefreshing() bool {
 	return c.refreshing
 }
 
 func (c *ListColumn) SetItems(rawItems interface{}) {
 	c.loading = false
+	c.loadFailed = false
 	c.cursor = 0
 	c.offset = 0
 	c.clearFilter()
@@ -773,6 +782,13 @@ func (c *ListColumn) renderContent() string {
 		spinner := styles.SpinnerFrames[c.spinnerFrame%len(styles.SpinnerFrames)]
 		loadingLine := styles.DimStyle.Render(spinner + " Loading...")
 		return titleLine + "\n" + " " + "\n" + loadingLine + "\n" + " "
+	}
+
+	// Failed load: actionable dead-end instead of an infinite spinner
+	if c.loadFailed && len(c.items) == 0 {
+		failedLine := styles.ErrorStyle.Render("✗ Failed to load")
+		retryLine := styles.DimStyle.Render("press r to retry")
+		return titleLine + "\n" + " " + "\n" + failedLine + "\n" + retryLine
 	}
 
 	count := c.ItemCount()
@@ -1239,15 +1255,22 @@ func (c *ListColumn) columnSortable() bool {
 
 // Sort methods
 
-// ApplySort sets the sort field and direction, rebuilds sortedIdx, and resets view
+// ApplySort sets the sort field and direction and rebuilds sortedIdx.
+// An active filter survives the re-sort: sorting a filtered list must not
+// silently expand it back to everything.
 func (c *ListColumn) ApplySort(field SortField, dir SortDirection) {
 	c.sortField = field
 	c.sortDir = dir
-	c.clearFilter()
 	c.cursor = 0
 	c.offset = 0
 
 	c.buildSortedIdx()
+
+	if c.filterActive && c.filterQuery != "" {
+		c.applyFilter()
+	} else {
+		c.filteredIdx = nil
+	}
 }
 
 // SortState returns the current sort field and direction

--- a/internal/tui/components/playlist_modal.go
+++ b/internal/tui/components/playlist_modal.go
@@ -204,14 +204,11 @@ func (m *PlaylistModal) View() string {
 
 	var lines []string
 
-	// Title
+	// Title: show which item the checkboxes affect — the modal opens async,
+	// so the cursor may have moved since it was requested
 	title := "Manage Playlists"
 	if m.item != nil {
-		itemTitle := m.item.Title
-		if len(itemTitle) > 25 {
-			itemTitle = itemTitle[:22] + "..."
-		}
-		title = "Add to Playlist"
+		title = "Add to Playlist: " + styles.Truncate(m.item.Title, 25)
 	}
 	titleLine := styles.ModalTitleStyle.Render(title)
 	lines = append(lines, titleLine)

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -12,12 +12,16 @@ import (
 func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
+	// Ctrl+C always quits, even inside modals and text inputs
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+
 	// Handle state-specific keys
 	switch m.State {
 	case StateHelp:
-		if key.Matches(msg, Keys.Escape, Keys.Help, Keys.Quit) {
-			m.State = StateBrowsing
-		}
+		// Any key returns to browsing, as the help screen promises
+		m.State = StateBrowsing
 		return m, nil
 
 	case StateConfirmLogout:
@@ -28,6 +32,23 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, Keys.Deny):
 			// User cancelled
 			m.State = StateBrowsing
+		}
+		return m, nil
+
+	case StateConfirmDeletePlaylist:
+		switch {
+		case key.Matches(msg, Keys.Confirm):
+			m.State = StateBrowsing
+			if m.pendingDeletePlaylistID != "" {
+				id := m.pendingDeletePlaylistID
+				m.pendingDeletePlaylistID = ""
+				m.pendingDeletePlaylistName = ""
+				return m, DeletePlaylistCmd(m.PlaylistService, id)
+			}
+		case key.Matches(msg, Keys.Deny), key.Matches(msg, Keys.Escape):
+			m.State = StateBrowsing
+			m.pendingDeletePlaylistID = ""
+			m.pendingDeletePlaylistName = ""
 		}
 		return m, nil
 	}
@@ -167,6 +188,7 @@ func (m Model) handleDrillIn() (tea.Model, tea.Cmd) {
 	}
 	if !top.CanDrillInto() {
 		if item := top.SelectedMediaItem(); item != nil {
+			m.StatusMsg = "Launching: " + item.Title
 			return m, PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume())
 		}
 		return m, nil
@@ -185,6 +207,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		return m.drillIntoSelection()
 	}
 	if item := top.SelectedMediaItem(); item != nil {
+		m.StatusMsg = "Launching: " + item.Title
 		return m, PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume())
 	}
 	return m, nil
@@ -207,10 +230,11 @@ func (m Model) handleSort() (tea.Model, tea.Cmd) {
 	case components.ColumnTypeMixed:
 		opts = components.MixedSortOptions()
 	}
-	if opts != nil {
-		field, dir := top.SortState()
-		m.SortModal.Show(opts, field, dir)
+	if opts == nil {
+		return m.notAvailableHere("Sort (s)")
 	}
+	field, dir := top.SortState()
+	m.SortModal.Show(opts, field, dir)
 	return m, nil
 }
 
@@ -333,7 +357,7 @@ func (m Model) handleMarkWatched() (tea.Model, tea.Cmd) {
 	}
 	item := top.SelectedMediaItem()
 	if item == nil {
-		return m, nil
+		return m.notAvailableHere("Mark watched (w)")
 	}
 	return m, MarkWatchedCmd(m.PlaybackSvc, item.ID, item.Title)
 }
@@ -346,7 +370,7 @@ func (m Model) handleMarkUnwatched() (tea.Model, tea.Cmd) {
 	}
 	item := top.SelectedMediaItem()
 	if item == nil {
-		return m, nil
+		return m.notAvailableHere("Mark unwatched (u)")
 	}
 	return m, MarkUnwatchedCmd(m.PlaybackSvc, item.ID, item.Title)
 }
@@ -359,9 +383,17 @@ func (m Model) handlePlay() (tea.Model, tea.Cmd) {
 	}
 	item := top.SelectedMediaItem()
 	if item == nil {
-		return m, nil
+		return m.notAvailableHere("Play (p)")
 	}
+	m.StatusMsg = "Launching: " + item.Title
 	return m, PlayItemCmd(m.PlaybackSvc, *item, false)
+}
+
+// notAvailableHere emits a short status explaining that a key does nothing
+// for the current selection, instead of silently ignoring it
+func (m Model) notAvailableHere(action string) (tea.Model, tea.Cmd) {
+	m.StatusMsg = action + " is not available for this item"
+	return m, ClearStatusCmd(3 * time.Second)
 }
 
 // handleToggleInspector toggles the inspector panel visibility
@@ -384,10 +416,11 @@ func (m Model) handlePlaylistModal() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	item := top.SelectedMediaItem()
-	if item != nil && m.PlaylistService != nil {
-		return m, LoadPlaylistModalDataCmd(m.PlaylistService, item)
+	if item == nil || m.PlaylistService == nil {
+		return m.notAvailableHere("Playlists (space)")
 	}
-	return m, nil
+	m.StatusMsg = "Loading playlists..."
+	return m, LoadPlaylistModalDataCmd(m.PlaylistService, item)
 }
 
 // handleDelete handles deletion of playlists or playlist items
@@ -403,10 +436,16 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 			return m, RemoveFromPlaylistCmd(m.PlaylistService, m.currentPlaylistID, item.ID)
 		}
 	case components.ColumnTypePlaylists:
-		playlist := top.SelectedPlaylist()
-		if playlist != nil {
-			return m, DeletePlaylistCmd(m.PlaylistService, playlist.ID)
+		// Deleting a playlist is irreversible and server-side: confirm first
+		if playlist := top.SelectedPlaylist(); playlist != nil {
+			m.State = StateConfirmDeletePlaylist
+			m.pendingDeletePlaylistID = playlist.ID
+			m.pendingDeletePlaylistName = playlist.Title
+			return m, nil
 		}
+	default:
+		m.StatusMsg = "Remove (x) only works in playlists"
+		return m, ClearStatusCmd(3 * time.Second)
 	}
 	return m, nil
 }

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -1,6 +1,9 @@
 package styles
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+)
 
 // Color palette
 var (
@@ -172,29 +175,28 @@ var (
 
 // Helper functions
 
-// Truncate truncates a string to the given width with ellipsis
+// Truncate truncates a string to the given display width with ellipsis.
+// Display-width aware: byte slicing splits multibyte runes (mojibake) and
+// miscounts CJK/emoji cell widths.
 func Truncate(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	if len(s) <= width {
+	if runewidth.StringWidth(s) <= width {
 		return s
 	}
 	if width <= 3 {
-		if width > len(s) {
-			return s
-		}
-		return s[:width]
+		return runewidth.Truncate(s, width, "")
 	}
-	return s[:width-3] + "..."
+	return runewidth.Truncate(s, width, "...")
 }
 
-// Pad pads a string to the given width
+// Pad pads a string to the given display width
 func Pad(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
+	if runewidth.StringWidth(s) >= width {
+		return runewidth.Truncate(s, width, "")
 	}
-	return s + spaces(width-len(s))
+	return runewidth.FillRight(s, width)
 }
 
 func spaces(n int) string {

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -30,6 +30,10 @@ func (m Model) View() string {
 		return m.renderLogoutConfirmation()
 	}
 
+	if m.State == StateConfirmDeletePlaylist {
+		return m.renderDeletePlaylistConfirmation()
+	}
+
 	contentHeight := m.Height - ChromeHeight
 	stackLen := m.ColumnStack.Len()
 	layout := m.calculateColumnLayout(m.Width)
@@ -201,18 +205,19 @@ func (m Model) renderHelp() string {
 NAVIGATION                      PLAYBACK
   j/k        Up/down               Enter  Play/resume
   h/l        Back/drill in         p      Play from start
-  g/Home     First item            w      Mark watched
-  G/End      Last item             u      Mark unwatched
-  PgUp/PgDn  Scroll page
-  Ctrl+u/d   Scroll half page
-
-SEARCH & VIEW                   OTHER
-  /          Filter                r      Refresh library
-  f          Global search         R      Refresh all
-  s          Sort                  q      Quit
-  i          Toggle inspector      ?      This help
-  Space      Manage playlists      Esc    Close / Cancel
+  Backspace  Back                  w      Mark watched
+  g/Home     First item            u      Mark unwatched
+  G/End      Last item
+  PgUp/PgDn  Scroll page         PLAYLISTS
+  Ctrl+u/d   Scroll half page      Space  Add/remove item
+                                   x      Delete / remove
+SEARCH & VIEW
+  /          Filter              OTHER
+  f          Global search         r      Refresh view
+  s          Sort                  R      Refresh all
+  i          Toggle inspector      q      Quit
                                    L      Logout
+                                   Esc    Close / Cancel
 
 Press any key to return...
 `
@@ -232,6 +237,24 @@ func (m Model) renderLogoutConfirmation() string {
 
         [Y] Yes      [N] No
 `
+
+	return lipgloss.Place(m.Width, m.Height,
+		lipgloss.Center, lipgloss.Center,
+		styles.ModalStyle.Render(modal))
+}
+
+// renderDeletePlaylistConfirmation renders the playlist delete confirmation
+func (m Model) renderDeletePlaylistConfirmation() string {
+	name := styles.Truncate(m.pendingDeletePlaylistName, 30)
+	modal := fmt.Sprintf(`
+        Delete Playlist?
+
+  %q
+  will be permanently deleted
+  from the server.
+
+      [Y] Yes      [N] No
+`, name)
 
 	return lipgloss.Place(m.Width, m.Height,
 		lipgloss.Center, lipgloss.Center,


### PR DESCRIPTION
UX batch from docs/design-review.md (C2, C3, C5, C6, C7, C8, M10, plus sort-preserves-filter):

- **Playlist delete confirmation** using the same y/n modal pattern as logout.
- **Ctrl+C always quits** — previously consumed by whichever modal/text input was focused.
- **Failed loads are recoverable**: the column renders an error state with a retry hint instead of spinning forever while the footer error disappears after 5s.
- **Sort modal**: `h` now closes (app-wide back semantics) instead of applying an ascending sort; `←` still applies ascending. `ApplySort` reapplies the active filter instead of clearing it.
- **Silent no-ops now explain themselves** ("Mark watched (w) is not available for this item").
- **Playback feedback**: instant "Launching: title" status, auto-clearing "Launched", playlist modal titled with the affected item and a pending status while its data loads.
- **Help/README truth**: help screen matches actual bindings and exits on any key; README table fixes wrong/missing entries.
- **Display-width-aware truncate/pad** (go-runewidth): CJK/accented titles render without mojibake and columns stay aligned.

Verified: full suite passes; drove the TUI to confirm the new help renders and any-key exit works.