### PR TITLE
Cleanup: dead code, config fixes, store hardening, setup flow

### DIFF
--- a/cmd/kino/main.go
+++ b/cmd/kino/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -66,7 +67,11 @@ func run() error {
 
 	// Check if configured
 	if !cfg.IsConfigured() {
-		return runSetupFlow(cfg, logger)
+		if err := runSetupFlow(cfg, logger); err != nil {
+			return err
+		}
+		// Fall through into normal startup with the fresh credentials —
+		// no need to make the user run kino a second time
 	}
 
 	// Create media source client
@@ -138,6 +143,12 @@ func runSetupFlow(cfg *config.Config, logger *slog.Logger) error {
 			continue
 		}
 
+		// Scheme-less input ("192.168.1.100:32400") would otherwise die with
+		// a cryptic "unsupported protocol scheme" error
+		if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
+			serverURL = "http://" + serverURL
+		}
+
 		// Detect server type with spinner
 		fmt.Println()
 		detectedType, err := detectServerWithSpinner(serverURL)
@@ -162,7 +173,10 @@ func runSetupFlow(cfg *config.Config, logger *slog.Logger) error {
 		return fmt.Errorf("failed to create auth flow: %w", err)
 	}
 
-	ctx := context.Background()
+	// Ctrl+C during the (up to 5-minute) PIN wait should cancel cleanly
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
 	result, err := authFlow.Run(ctx, serverURL)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
@@ -178,9 +192,7 @@ func runSetupFlow(cfg *config.Config, logger *slog.Logger) error {
 	}
 
 	fmt.Println()
-	fmt.Println("✓ Configuration saved!")
-	fmt.Println()
-	fmt.Println("Run kino again to start the application.")
+	fmt.Println("✓ Configuration saved! Starting kino...")
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -103,9 +104,23 @@ func LoadConfig() (*Config, error) {
 	// The config file contains the server token: never world-readable
 	viper.SetConfigPermissions(0o600)
 
-	// Environment variable overrides
+	// Environment variable overrides. Both pieces are required for nested
+	// keys to actually work: the replacer maps server.token →
+	// KINO_SERVER_TOKEN, and explicit BindEnv registers each key so
+	// Unmarshal sees env-only values (AutomaticEnv alone is invisible to
+	// Unmarshal for keys absent from defaults/config).
 	viper.SetEnvPrefix("KINO")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
+	for _, key := range []string{
+		"server.type", "server.url", "server.token", "server.user_id",
+		"server.username", "server.device_id",
+		"player.command", "player.start_flag",
+		"ui.show_watch_status", "ui.show_library_counts",
+		"logging.file", "logging.level",
+	} {
+		_ = viper.BindEnv(key)
+	}
 
 	// Read config file if it exists
 	if err := viper.ReadInConfig(); err != nil {
@@ -153,13 +168,17 @@ func generateDeviceID() string {
 	return "kino-" + hex.EncodeToString(buf)
 }
 
-// SaveConfig saves the current configuration to file
+// SaveConfig saves the current configuration, writing back to the file that
+// was loaded (a ./config.yaml stays in place instead of forking a stale copy
+// into the default path) or to the default path for fresh installs.
 func SaveConfig(cfg *Config) error {
-	configPath := defaultConfigPath()
-
-	// Ensure config directory exists
-	if err := os.MkdirAll(configPath, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	configFile := viper.ConfigFileUsed()
+	if configFile == "" {
+		configPath := defaultConfigPath()
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %w", err)
+		}
+		configFile = filepath.Join(configPath, "config.yaml")
 	}
 
 	viper.SetConfigPermissions(0o600)
@@ -185,7 +204,6 @@ func SaveConfig(cfg *Config) error {
 	viper.Set("logging.file", cfg.Logging.File)
 	viper.Set("logging.level", cfg.Logging.Level)
 
-	configFile := filepath.Join(configPath, "config.yaml")
 	if err := viper.WriteConfigAs(configFile); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
@@ -219,13 +237,19 @@ func ClearServerConfig() error {
 	viper.Set("server.user_id", "")
 	viper.Set("server.username", "")
 
-	configPath := defaultConfigPath()
-	if err := os.MkdirAll(configPath, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	// Write back to the loaded config file: clearing credentials in a copy
+	// at the default path while a ./config.yaml still holds the token would
+	// be a sign-out that doesn't sign out
+	configFile := viper.ConfigFileUsed()
+	if configFile == "" {
+		configPath := defaultConfigPath()
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %w", err)
+		}
+		configFile = filepath.Join(configPath, "config.yaml")
 	}
 
 	viper.SetConfigPermissions(0o600)
-	configFile := filepath.Join(configPath, "config.yaml")
 	if err := viper.WriteConfigAs(configFile); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,27 @@ import (
 	"testing"
 )
 
+// KINO_* environment overrides must reach the unmarshaled config — they were
+// previously dead (no env key replacer, no BindEnv registration).
+func TestEnvVarOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("APPDATA", home)
+	t.Setenv("KINO_SERVER_TOKEN", "env-token")
+	t.Setenv("KINO_LOGGING_LEVEL", "DEBUG")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.Token != "env-token" {
+		t.Fatalf("KINO_SERVER_TOKEN ignored: token = %q", cfg.Server.Token)
+	}
+	if cfg.Logging.Level != "DEBUG" {
+		t.Fatalf("KINO_LOGGING_LEVEL ignored: level = %q", cfg.Logging.Level)
+	}
+}
+
 // TestLoadConfigGeneratesDeviceID verifies that an already-configured install
 // without a device_id (pre-existing config.yaml) gets a unique ID generated
 // and persisted, so the ID stays stable across runs.

--- a/internal/mediaserver/client.go
+++ b/internal/mediaserver/client.go
@@ -19,11 +19,6 @@ type MediaSource interface {
 	domain.PlaybackClient // Playback: ResolvePlayableURL, MarkPlayed/Unplayed
 	domain.SearchClient   // Search: Search(query) across all libraries
 	domain.PlaylistClient // Playlists: GetPlaylists, CreatePlaylist, AddToPlaylist, etc.
-
-	// GetMediaItem fetches full metadata for a single item.
-	// Kept on MediaSource (not in a domain interface) as it's only used
-	// by specific features that need detailed item metadata.
-	GetMediaItem(ctx context.Context, itemID string) (*domain.MediaItem, error)
 }
 
 // NewClient creates a new MediaSource based on the server type.

--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -413,35 +413,6 @@ func (c *Client) ResolvePlayableURL(ctx context.Context, itemID string) (string,
 	return streamURL, nil
 }
 
-// GetMediaItem returns detailed metadata for a specific item
-func (c *Client) GetMediaItem(ctx context.Context, itemID string) (*domain.MediaItem, error) {
-	query := url.Values{}
-	query.Set("Fields", "Overview,MediaSources,MediaStreams,DateCreated")
-
-	path := fmt.Sprintf("/Users/%s/Items/%s", c.userID, itemID)
-	body, err := c.doRequest(ctx, http.MethodGet, path, query)
-	if err != nil {
-		return nil, err
-	}
-
-	var item Item
-	if err := json.Unmarshal(body, &item); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	var result domain.MediaItem
-	switch item.Type {
-	case "Movie":
-		result = mapMovie(item, c.baseURL)
-	case "Episode":
-		result = mapEpisode(item, c.baseURL)
-	default:
-		return nil, domain.ErrItemNotFound
-	}
-
-	return &result, nil
-}
-
 // MarkPlayed marks an item as fully watched
 func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 	path := fmt.Sprintf("/Users/%s/PlayedItems/%s", c.userID, itemID)

--- a/internal/mediaserver/plex/client.go
+++ b/internal/mediaserver/plex/client.go
@@ -417,27 +417,6 @@ func (c *Client) ResolvePlayableURL(ctx context.Context, itemID string) (string,
 	return fmt.Sprintf("%s%s?X-Plex-Token=%s", c.baseURL, mediaPath, c.token), nil
 }
 
-// GetMediaItem returns detailed metadata for a specific item
-func (c *Client) GetMediaItem(ctx context.Context, itemID string) (*domain.MediaItem, error) {
-	path := fmt.Sprintf("/library/metadata/%s", itemID)
-	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	container, err := c.parseResponse(body)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(container.Metadata) == 0 {
-		return nil, domain.ErrItemNotFound
-	}
-
-	item := MapMediaItem(container.Metadata[0], c.baseURL)
-	return &item, nil
-}
-
 // MarkPlayed marks an item as fully watched
 func (c *Client) MarkPlayed(ctx context.Context, itemID string) error {
 	query := url.Values{}

--- a/internal/playlist/service.go
+++ b/internal/playlist/service.go
@@ -3,6 +3,7 @@ package playlist
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/mmcdole/kino/internal/domain"
 )
@@ -129,27 +130,46 @@ func (s *Service) GetPlaylistMembership(ctx context.Context, itemID string) (map
 		}
 	}
 
-	membership := make(map[string]bool)
+	// Check each playlist's items concurrently: uncached playlists each cost
+	// a network round-trip, and doing them serially under the modal's single
+	// timeout made the playlist modal time out on large collections
+	const maxConcurrent = 4
+	sem := make(chan struct{}, maxConcurrent)
 
-	// Check each playlist's items, fetching from server if not cached
+	var (
+		mu         sync.Mutex
+		wg         sync.WaitGroup
+		membership = make(map[string]bool)
+	)
+
 	for _, p := range playlists {
-		items, ok := s.store.GetPlaylistItems(p.ID)
-		if !ok {
-			var err error
-			items, err = s.FetchPlaylistItems(ctx, p.ID)
-			if err != nil {
-				s.logger.Error("failed to fetch playlist items for membership check", "error", err, "playlistID", p.ID)
-				continue
-			}
-		}
+		wg.Add(1)
+		go func(p *domain.Playlist) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 
-		for _, item := range items {
-			if item.ID == itemID {
-				membership[p.ID] = true
-				break
+			items, ok := s.store.GetPlaylistItems(p.ID)
+			if !ok {
+				var err error
+				items, err = s.FetchPlaylistItems(ctx, p.ID)
+				if err != nil {
+					s.logger.Error("failed to fetch playlist items for membership check", "error", err, "playlistID", p.ID)
+					return
+				}
 			}
-		}
+
+			for _, item := range items {
+				if item.ID == itemID {
+					mu.Lock()
+					membership[p.ID] = true
+					mu.Unlock()
+					return
+				}
+			}
+		}(p)
 	}
+	wg.Wait()
 
 	return membership, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,10 +37,16 @@ type listItemWrapper struct {
 // LibraryStore implements domain.Store using BoltDB.
 type LibraryStore struct {
 	db *bolt.DB
-	mu sync.RWMutex // Protects memory cache
+	mu sync.RWMutex // Protects memory cache and gen
 
 	// In-memory cache for hot-path reads (promoted on access)
 	cache map[string][]byte
+
+	// gen increments on every invalidation. get() records it before the
+	// unlocked BoltDB read and skips cache promotion if it changed, so a
+	// concurrent invalidation can't be undone by resurrecting deleted data
+	// into the memory cache.
+	gen uint64
 }
 
 // NewLibraryStore opens (or creates) the cache for one server+user pair.
@@ -122,6 +128,7 @@ func (s *LibraryStore) get(bucket []byte, key string, dest interface{}) bool {
 		s.mu.RUnlock()
 		return json.Unmarshal(data, dest) == nil
 	}
+	genBefore := s.gen
 	s.mu.RUnlock()
 
 	if s.db == nil {
@@ -146,9 +153,12 @@ func (s *LibraryStore) get(bucket []byte, key string, dest interface{}) bool {
 		return false
 	}
 
-	// Promote to memory cache
+	// Promote to memory cache — unless an invalidation ran while we were
+	// reading, in which case this data may already be deleted
 	s.mu.Lock()
-	s.cache[cacheKey] = data
+	if s.gen == genBefore {
+		s.cache[cacheKey] = data
+	}
 	s.mu.Unlock()
 
 	return json.Unmarshal(data, dest) == nil
@@ -160,22 +170,52 @@ func (s *LibraryStore) set(bucket []byte, key string, value interface{}) error {
 		return err
 	}
 
-	cacheKey := string(bucket) + ":" + key
-
-	// Update memory cache
-	s.mu.Lock()
-	s.cache[cacheKey] = data
-	s.mu.Unlock()
-
-	if s.db == nil {
-		return nil // Memory-only mode
+	// Durable write first: a failed BoltDB write must not leave a memory
+	// cache that disagrees with disk until restart
+	if s.db != nil {
+		if err := s.db.Update(func(tx *bolt.Tx) error {
+			return tx.Bucket(bucket).Put([]byte(key), data)
+		}); err != nil {
+			return err
+		}
 	}
 
-	// Write to BoltDB
-	return s.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucket)
-		return b.Put([]byte(key), data)
-	})
+	s.mu.Lock()
+	s.cache[string(bucket)+":"+key] = data
+	s.mu.Unlock()
+	return nil
+}
+
+// setContentPair writes a content payload and its freshness timestamp in a
+// single transaction, so readers can never observe new data with an old
+// timestamp or vice versa.
+func (s *LibraryStore) setContentPair(dataKey string, value interface{}, tsKey string, serverTS int64) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	tsData, err := json.Marshal(serverTS)
+	if err != nil {
+		return err
+	}
+
+	if s.db != nil {
+		if err := s.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket(bucketContent)
+			if err := b.Put([]byte(dataKey), data); err != nil {
+				return err
+			}
+			return b.Put([]byte(tsKey), tsData)
+		}); err != nil {
+			return err
+		}
+	}
+
+	s.mu.Lock()
+	s.cache[string(bucketContent)+":"+dataKey] = data
+	s.cache[string(bucketContent)+":"+tsKey] = tsData
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *LibraryStore) delete(bucket []byte, key string) {
@@ -183,6 +223,7 @@ func (s *LibraryStore) delete(bucket []byte, key string) {
 
 	// Clear from memory cache
 	s.mu.Lock()
+	s.gen++
 	delete(s.cache, cacheKey)
 	s.mu.Unlock()
 
@@ -203,6 +244,7 @@ func (s *LibraryStore) delete(bucket []byte, key string) {
 func (s *LibraryStore) deletePrefix(bucket []byte, prefix string) {
 	// Clear from memory cache
 	s.mu.Lock()
+	s.gen++
 	cachePrefix := string(bucket) + ":" + prefix
 	for k := range s.cache {
 		if strings.HasPrefix(k, cachePrefix) {
@@ -253,12 +295,7 @@ func (s *LibraryStore) GetMovies(libID string) ([]*domain.MediaItem, bool) {
 }
 
 func (s *LibraryStore) SaveMovies(libID string, movies []*domain.MediaItem, serverTS int64) error {
-	// Save data
-	if err := s.set(bucketContent, "lib:"+libID+":movies", movies); err != nil {
-		return err
-	}
-	// Save timestamp separately for freshness checks
-	return s.set(bucketContent, "lib:"+libID+":ts", serverTS)
+	return s.setContentPair("lib:"+libID+":movies", movies, "lib:"+libID+":ts", serverTS)
 }
 
 // === Shows ===
@@ -270,10 +307,7 @@ func (s *LibraryStore) GetShows(libID string) ([]*domain.Show, bool) {
 }
 
 func (s *LibraryStore) SaveShows(libID string, shows []*domain.Show, serverTS int64) error {
-	if err := s.set(bucketContent, "lib:"+libID+":shows", shows); err != nil {
-		return err
-	}
-	return s.set(bucketContent, "lib:"+libID+":ts", serverTS)
+	return s.setContentPair("lib:"+libID+":shows", shows, "lib:"+libID+":ts", serverTS)
 }
 
 // === Mixed Content ===
@@ -287,10 +321,7 @@ func (s *LibraryStore) GetMixedContent(libID string) ([]domain.ListItem, bool) {
 }
 
 func (s *LibraryStore) SaveMixedContent(libID string, items []domain.ListItem, serverTS int64) error {
-	if err := s.set(bucketContent, "lib:"+libID+":mixed", wrapListItems(items)); err != nil {
-		return err
-	}
-	return s.set(bucketContent, "lib:"+libID+":ts", serverTS)
+	return s.setContentPair("lib:"+libID+":mixed", wrapListItems(items), "lib:"+libID+":ts", serverTS)
 }
 
 // === Seasons (hierarchical key: lib:{libID}:show:{showID}) ===
@@ -646,6 +677,7 @@ func (s *LibraryStore) InvalidateSeason(libID, showID, seasonID string) {
 
 func (s *LibraryStore) InvalidateAll() {
 	s.mu.Lock()
+	s.gen++
 	s.cache = make(map[string][]byte)
 	s.mu.Unlock()
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -457,15 +457,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				// Trigger delayed cleanup
 				cmds = append(cmds, ClearLibraryStatusCmd(msg.LibraryID, 2*time.Second))
-
-				// If we're at library level and this is selected library, show its content
-				if m.ColumnStack.Len() == 1 {
-					if libCol := m.ColumnStack.Top(); libCol != nil {
-						if lib := libCol.SelectedLibrary(); lib != nil && lib.ID == msg.LibraryID {
-							// Don't auto-drill; user must press l/Enter
-						}
-					}
-				}
 			}
 		}
 

--- a/internal/tui/column_stack.go
+++ b/internal/tui/column_stack.go
@@ -105,25 +105,9 @@ func (cs *ColumnStack) Reset(col *components.ListColumn) {
 	cs.columns = append(cs.columns, col)
 }
 
-// Parent returns the parent column (second from top), or nil if at root
-func (cs *ColumnStack) Parent() *components.ListColumn {
-	if len(cs.columns) < 2 {
-		return nil
-	}
-	return cs.columns[len(cs.columns)-2]
-}
-
 // CanGoBack returns true if we can navigate back (not at root)
 func (cs *ColumnStack) CanGoBack() bool {
 	return len(cs.columns) > 1
-}
-
-// Depth returns the navigation depth (0 = root, 1 = first drill, etc.)
-func (cs *ColumnStack) Depth() int {
-	if len(cs.columns) == 0 {
-		return 0
-	}
-	return len(cs.columns) - 1
 }
 
 // UpdateTop replaces the top column with the given column.

--- a/internal/tui/components/global_search.go
+++ b/internal/tui/components/global_search.go
@@ -22,7 +22,6 @@ type GlobalSearch struct {
 	visible   bool
 	width     int
 	height    int
-	loading   bool
 	prevQuery string
 }
 
@@ -52,7 +51,6 @@ func (o *GlobalSearch) Show() {
 	o.results = nil
 	o.cursor = 0
 	o.offset = 0
-	o.loading = false
 	o.prevQuery = ""
 }
 
@@ -72,7 +70,6 @@ func (o *GlobalSearch) SetResults(results []search.FilterResult) {
 	o.results = results
 	o.cursor = 0
 	o.offset = 0
-	o.loading = false
 }
 
 // SetSize updates the component dimensions
@@ -199,11 +196,7 @@ func (o GlobalSearch) View() string {
 	b.WriteString("\n\n")
 
 	// Results
-	if o.loading {
-		b.WriteString(styles.SpinnerStyle.Render("Searching..."))
-	} else {
-		o.renderResults(&b, modalWidth, maxResults)
-	}
+	o.renderResults(&b, modalWidth, maxResults)
 
 	// Center the modal
 	content := lipgloss.NewStyle().

--- a/internal/tui/components/inspector.go
+++ b/internal/tui/components/inspector.go
@@ -3,8 +3,8 @@ package components
 import (
 	"fmt"
 	"strings"
+	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mmcdole/kino/internal/domain"
 	"github.com/mmcdole/kino/internal/tui/styles"
@@ -60,16 +60,6 @@ func (i *Inspector) SetSize(width, height int) {
 	if i.maxVisible < 1 {
 		i.maxVisible = 1
 	}
-}
-
-// HasItem returns true if there is an item to display
-func (i Inspector) HasItem() bool {
-	return i.item != nil
-}
-
-// Update handles messages (currently no-op, inspector is not focusable)
-func (i Inspector) Update(_ tea.Msg) (Inspector, tea.Cmd) {
-	return i, nil
 }
 
 // View renders the component
@@ -532,22 +522,8 @@ func splitLines(s string) []string {
 }
 
 // formatDuration formats a duration as HH:MM:SS or MM:SS
-func formatDuration(d interface{}) string {
-	var totalSeconds int64
-
-	switch v := d.(type) {
-	case int64:
-		totalSeconds = v / 1000 // assuming milliseconds
-	case int:
-		totalSeconds = int64(v) / 1000
-	default:
-		// Try to handle time.Duration
-		if dur, ok := d.(interface{ Seconds() float64 }); ok {
-			totalSeconds = int64(dur.Seconds())
-		} else {
-			return "00:00"
-		}
-	}
+func formatDuration(d time.Duration) string {
+	totalSeconds := int64(d.Seconds())
 
 	hours := totalSeconds / 3600
 	minutes := (totalSeconds % 3600) / 60

--- a/internal/tui/components/list_column.go
+++ b/internal/tui/components/list_column.go
@@ -227,14 +227,6 @@ func (c *ListColumn) SetSize(width, height int) {
 	c.ensureVisible() // Scroll to show selected item now that we know the size
 }
 
-func (c *ListColumn) Width() int {
-	return c.width
-}
-
-func (c *ListColumn) Height() int {
-	return c.height
-}
-
 func (c *ListColumn) SetFocused(focused bool) {
 	c.focused = focused
 }
@@ -301,10 +293,6 @@ func (c *ListColumn) CanDrillInto() bool {
 		return false
 	}
 	return c.items[idx].CanDrillDown()
-}
-
-func (c *ListColumn) IsEmpty() bool {
-	return c.ItemCount() == 0
 }
 
 func (c *ListColumn) SetLoading(loading bool) {
@@ -601,19 +589,6 @@ func (c *ListColumn) SelectedPlaylist() *domain.Playlist {
 		return nil
 	}
 	return item.(*domain.Playlist)
-}
-
-// FindIndexByID finds the index of an item by its ID. Returns -1 if not found.
-func (c *ListColumn) FindIndexByID(id string) int {
-	if id == "" {
-		return -1
-	}
-	for i, item := range c.items {
-		if item.GetID() == id {
-			return i
-		}
-	}
-	return -1
 }
 
 // SetSelectedByID finds an item by ID and selects it. Returns true on success.

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -450,13 +450,13 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleNewPlaylist shows hint about creating playlists
+// handleNewPlaylist opens the new-playlist name input (playlists column only)
 func (m Model) handleNewPlaylist() (tea.Model, tea.Cmd) {
 	top := m.ColumnStack.Top()
-	if top != nil && top.ColumnType() == components.ColumnTypePlaylists {
-		m.StatusMsg = "Use Space on an item to create a playlist"
-		return m, ClearStatusCmd(3 * time.Second)
+	if top == nil || top.ColumnType() != components.ColumnTypePlaylists {
+		return m, nil
 	}
+	m.InputModal.Show("New Playlist")
 	return m, nil
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -5,17 +5,9 @@ import "github.com/charmbracelet/bubbles/key"
 // KeyMap defines all key bindings for the application
 type KeyMap struct {
 	// Navigation
-	Up       key.Binding
-	Down     key.Binding
-	Right    key.Binding
-	Enter    key.Binding
-	Back     key.Binding
-	HalfUp   key.Binding
-	HalfDown key.Binding
-	PageUp   key.Binding
-	PageDown key.Binding
-	Home     key.Binding
-	End      key.Binding
+	Right key.Binding
+	Enter key.Binding
+	Back  key.Binding
 
 	// Actions
 	Quit            key.Binding
@@ -44,14 +36,6 @@ type KeyMap struct {
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
 		// Navigation
-		Up: key.NewBinding(
-			key.WithKeys("k", "up"),
-			key.WithHelp("k/↑", "up"),
-		),
-		Down: key.NewBinding(
-			key.WithKeys("j", "down"),
-			key.WithHelp("j/↓", "down"),
-		),
 		Right: key.NewBinding(
 			key.WithKeys("l", "right"),
 			key.WithHelp("l/→", "expand"),
@@ -63,30 +47,6 @@ func DefaultKeyMap() KeyMap {
 		Back: key.NewBinding(
 			key.WithKeys("h", "left", "backspace"),
 			key.WithHelp("h/←", "back"),
-		),
-		HalfUp: key.NewBinding(
-			key.WithKeys("ctrl+u"),
-			key.WithHelp("C-u", "half page up"),
-		),
-		HalfDown: key.NewBinding(
-			key.WithKeys("ctrl+d"),
-			key.WithHelp("C-d", "half page down"),
-		),
-		PageUp: key.NewBinding(
-			key.WithKeys("pgup"),
-			key.WithHelp("PgUp", "page up"),
-		),
-		PageDown: key.NewBinding(
-			key.WithKeys("pgdown"),
-			key.WithHelp("PgDn", "page down"),
-		),
-		Home: key.NewBinding(
-			key.WithKeys("g", "home"),
-			key.WithHelp("g", "go to top"),
-		),
-		End: key.NewBinding(
-			key.WithKeys("G", "end"),
-			key.WithHelp("G", "go to bottom"),
 		),
 
 		// Actions

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -15,7 +15,6 @@ var (
 	White      = lipgloss.Color("#F9FAFB")
 	Green      = lipgloss.Color("#10B981")
 	Red        = lipgloss.Color("#EF4444")
-	Blue       = lipgloss.Color("#3B82F6")
 )
 
 // Borders
@@ -27,9 +26,6 @@ var (
 	InactiveBorder = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(DimGray)
-
-	NoBorder = lipgloss.NewStyle().
-			Border(lipgloss.HiddenBorder())
 )
 
 // Text styles
@@ -49,14 +45,6 @@ var (
 
 	ErrorStyle = lipgloss.NewStyle().
 			Foreground(Red)
-
-	SuccessStyle = lipgloss.NewStyle().
-			Foreground(Green)
-
-	HighlightStyle = lipgloss.NewStyle().
-			Foreground(White).
-			Background(PlexOrange).
-			Padding(0, 1)
 )
 
 // Raw watch status characters (unstyled)
@@ -73,13 +61,6 @@ var (
 	PlayedStyle     = lipgloss.NewStyle().Foreground(Green)
 )
 
-// Pre-rendered watch status indicators (for non-selection contexts)
-var (
-	UnplayedDot   = UnplayedStyle.Render(UnplayedChar)
-	InProgressDot = InProgressStyle.Render(InProgressChar)
-	PlayedCheck   = PlayedStyle.Render(PlayedChar)
-)
-
 // List item styles
 var (
 	SelectedItemStyle = lipgloss.NewStyle().
@@ -90,11 +71,6 @@ var (
 	NormalItemStyle = lipgloss.NewStyle().
 			Foreground(LightGray).
 			Padding(0, 1)
-
-	FocusedItemStyle = lipgloss.NewStyle().
-				Foreground(PlexOrange).
-				Bold(true).
-				Padding(0, 1)
 )
 
 // Modal styles
@@ -111,35 +87,12 @@ var (
 			MarginBottom(1)
 )
 
-// Help styles
-var (
-	HelpKeyStyle = lipgloss.NewStyle().
-			Foreground(PlexOrange)
-
-	HelpDescStyle = lipgloss.NewStyle().
-			Foreground(DimGray)
-)
-
-// Progress bar styles
-var (
-	ProgressFullStyle = lipgloss.NewStyle().
-				Foreground(PlexOrange)
-
-	ProgressEmptyStyle = lipgloss.NewStyle().
-				Foreground(DimGray)
-)
-
 // Badge styles
 var (
-	BadgeStyle = lipgloss.NewStyle().
-			Foreground(White).
-			Background(PlexOrange).
-			Padding(0, 1)
-
 	DimBadgeStyle = lipgloss.NewStyle().
-			Foreground(LightGray).
-			Background(SlateLight).
-			Padding(0, 1)
+		Foreground(LightGray).
+		Background(SlateLight).
+		Padding(0, 1)
 )
 
 // Spinner style
@@ -159,18 +112,6 @@ var (
 	FilterPromptStyle = lipgloss.NewStyle().
 				Foreground(PlexOrange).
 				Bold(true)
-)
-
-// Match highlight styles for search results
-var (
-	MatchHighlightStyle = lipgloss.NewStyle().
-				Foreground(PlexOrange).
-				Bold(true)
-
-	MatchHighlightSelectedStyle = lipgloss.NewStyle().
-					Foreground(PlexOrange).
-					Background(SlateLight).
-					Bold(true)
 )
 
 // Helper functions
@@ -208,28 +149,6 @@ func spaces(n int) string {
 		b[i] = ' '
 	}
 	return string(b)
-}
-
-// RenderProgressBar renders a progress bar
-func RenderProgressBar(percent float64, width int) string {
-	if width < 3 {
-		return ""
-	}
-
-	filled := int(float64(width) * percent / 100)
-	if filled > width {
-		filled = width
-	}
-
-	bar := ""
-	for i := 0; i < filled; i++ {
-		bar += ProgressFullStyle.Render("█")
-	}
-	for i := filled; i < width; i++ {
-		bar += ProgressEmptyStyle.Render("░")
-	}
-
-	return bar
 }
 
 // RenderListRow renders a complete list row with uniform background when selected.

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -11,8 +11,7 @@ import (
 
 // RenderSpinner renders a loading spinner
 func RenderSpinner(frame int) string {
-	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-	return styles.SpinnerStyle.Render(frames[frame%len(frames)])
+	return styles.SpinnerStyle.Render(styles.SpinnerFrames[frame%len(styles.SpinnerFrames)])
 }
 
 // View renders the application


### PR DESCRIPTION
Final batch from docs/design-review.md (A9, A11, A12, D9, L3, E):

- **Env overrides fixed (A11)**: `KINO_SERVER_TOKEN` etc. now work — viper needed both an env key replacer and per-key `BindEnv` for `Unmarshal` to see them. Test included.
- **cwd-config coherence (A12)**: save/clear write back to `viper.ConfigFileUsed()`, so sign-out clears the file that's actually loaded.
- **Setup flow (D9)**: no more "run kino again"; scheme-less URLs auto-prefixed; PIN wait cancels on Ctrl+C.
- **Store hardening (A9)**: bolt-first write ordering, atomic data+timestamp commits, generation-guarded cache promotion (closes the invalidation race).
- **Playlist membership (L3)**: bounded-concurrency fetches; the modal no longer times out on large collections.
- **Feature completion**: `n` opens the new-playlist input modal that was fully built but never wired.
- **Dead code**: ~230 lines deleted (unused interface method + impls, duplicate keymaps, unused component methods and styles, unreachable branches).

Full suite passes (13 packages), gofmt clean, e2e smoke against the fake Jellyfin server verified browse/watch-toggle still work.