### PR TITLE
Unify status feedback under a scoped notification model

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -102,16 +102,15 @@ type Model struct {
 	Height int
 
 	// UI state
-	StatusMsg     string
-	StatusIsErr   bool
-	Loading       bool
 	SpinnerFrame  int
 	ShowInspector bool // Toggle inspector visibility (default true)
 
+	// Footer notification (single slot; see notice.go for the rules)
+	notice    Notice
+	noticeSeq int
+
 	// Sync state
 	LibraryStates map[string]components.LibrarySyncState // Tracks progress per library
-	SyncingCount  int                                    // Libraries still syncing
-	MultiLibSync  bool                                   // True when syncing multiple libraries (R / startup)
 	SyncGen       int                                    // Current sync generation; messages from older generations are dropped
 
 	// Navigation plan for deep linking
@@ -201,10 +200,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.LibraryStates[lib.ID] = components.LibrarySyncState{Status: components.StatusSyncing}
 		}
 		m.LibraryStates[playlistsLibraryID] = components.LibrarySyncState{Status: components.StatusSyncing}
-		m.SyncingCount = len(msg.Libraries) + 1 // +1 for playlists
-		m.MultiLibSync = true
 		m.Inspector.SetLibraryStates(m.LibraryStates)
-		m.Loading = true
 
 		syncCmds := []tea.Cmd{
 			SyncAllLibrariesCmd(m.LibraryService, msg.Libraries, m.SyncGen),
@@ -229,9 +225,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// server-side — that's the one case where resetting is the
 			// only sane answer
 			if drilledID != "" && drilledID != playlistsLibraryID && m.findLibrary(drilledID) == nil {
-				m.StatusMsg = "Library no longer exists on server"
-				m.StatusIsErr = true
-				syncCmds = append(syncCmds, ClearStatusCmd(5*time.Second))
+				// Alert: it explains why navigation just reset; stays until
+				// the user dismisses it with Esc
+				m.notify(NoticeAlert, "Library no longer exists on server — navigation reset")
 			} else {
 				if reload := m.reloadTopColumnCmd(); reload != nil {
 					syncCmds = append(syncCmds, reload)
@@ -250,7 +246,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(syncCmds...)
 
 	case MoviesLoadedMsg:
-		m.Loading = false
 
 		// If manual load succeeded and library was in error state, clear it
 		if state, ok := m.LibraryStates[msg.LibraryID]; ok && state.Status == components.StatusError {
@@ -279,7 +274,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case ShowsLoadedMsg:
-		m.Loading = false
 
 		// If manual load succeeded and library was in error state, clear it
 		if state, ok := m.LibraryStates[msg.LibraryID]; ok && state.Status == components.StatusError {
@@ -308,7 +302,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case MixedLibraryLoadedMsg:
-		m.Loading = false
 
 		// If manual load succeeded and library was in error state, clear it
 		if state, ok := m.LibraryStates[msg.LibraryID]; ok && state.Status == components.StatusError {
@@ -337,7 +330,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case SeasonsLoadedMsg:
-		m.Loading = false
 
 		// Validate content ID to prevent race condition
 		if !m.validateContentID(msg.ShowID) {
@@ -358,7 +350,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case EpisodesLoadedMsg:
-		m.Loading = false
 
 		// Validate content ID to prevent race condition
 		if !m.validateContentID(msg.SeasonID) {
@@ -379,25 +370,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case PlaybackStartedMsg:
-		m.StatusMsg = "Launched: " + msg.Item.Title
-		return m, ClearStatusCmd(3 * time.Second)
+		return m, m.notify(NoticeSuccess, "Launched: "+msg.Item.Title)
 
 	case MarkWatchedMsg:
-		m.StatusMsg = "Marked watched: " + msg.Title
 		m.applyWatchState(msg.ItemID, true)
-		cmds = append(cmds, ClearStatusCmd(3*time.Second))
-		return m, tea.Batch(cmds...)
+		return m, m.notify(NoticeSuccess, "Marked watched: "+msg.Title)
 
 	case MarkUnwatchedMsg:
-		m.StatusMsg = "Marked unwatched: " + msg.Title
 		m.applyWatchState(msg.ItemID, false)
-		cmds = append(cmds, ClearStatusCmd(3*time.Second))
-		return m, tea.Batch(cmds...)
+		return m, m.notify(NoticeSuccess, "Marked unwatched: "+msg.Title)
 
 	case ErrMsg:
 		m.clearNavPlan()
-		m.StatusIsErr = true
-		m.Loading = false
 		// A failed refresh must not leave the column spinner running, and a
 		// failed initial load must show a retry hint, not spin forever
 		if top := m.ColumnStack.Top(); top != nil {
@@ -407,24 +391,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if errors.Is(msg.Err, domain.ErrAuthFailed) {
-			// Actionable, persistent message: the token was revoked/expired
-			// and the user must re-authenticate
-			m.StatusMsg = authFailedStatusMsg
+			// The token was revoked/expired and the user must re-authenticate
+			m.notify(NoticeAlert, authFailedStatusMsg)
 			return m, nil
 		}
-		m.StatusMsg = msg.Error()
-		cmds = append(cmds, ClearStatusCmd(5*time.Second))
-		return m, tea.Batch(cmds...)
+		return m, m.notify(NoticeError, msg.Error())
 
-	case StatusMsg:
-		m.StatusMsg = msg.Message
-		m.StatusIsErr = msg.IsError
-		cmds = append(cmds, ClearStatusCmd(3*time.Second))
-		return m, tea.Batch(cmds...)
-
-	case ClearStatusMsg:
-		m.StatusMsg = ""
-		m.StatusIsErr = false
+	case ClearNoticeMsg:
+		m.expireNotice(msg.Seq)
 		return m, nil
 
 	case LibrarySyncProgressMsg:
@@ -440,11 +414,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Error != nil {
 			state.Status = components.StatusError
 			state.Error = msg.Error
-			m.SyncingCount--
 			slog.Error("library sync failed", "libraryID", msg.LibraryID, "error", msg.Error)
 			if errors.Is(msg.Error, domain.ErrAuthFailed) {
-				m.StatusMsg = authFailedStatusMsg
-				m.StatusIsErr = true
+				m.notify(NoticeAlert, authFailedStatusMsg)
+			} else {
+				// The row's ✗ glyph may be off-screen; name the scope so the
+				// failure is visible wherever the user is
+				name := msg.LibraryID
+				if lib := m.findLibrary(msg.LibraryID); lib != nil {
+					name = lib.Name
+				} else if msg.LibraryID == playlistsLibraryID {
+					name = "Playlists"
+				}
+				cmds = append(cmds, m.notify(NoticeError, fmt.Sprintf("Sync failed: %s — r to retry", name)))
 			}
 		} else {
 			state.Loaded = msg.Loaded
@@ -453,7 +435,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if msg.Done {
 				state.Status = components.StatusSynced
-				m.SyncingCount--
 
 				// Trigger delayed cleanup
 				cmds = append(cmds, ClearLibraryStatusCmd(msg.LibraryID, 2*time.Second))
@@ -466,11 +447,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// If there's a continuation command, run it
 		if msg.NextCmd != nil {
 			cmds = append(cmds, msg.NextCmd)
-		}
-
-		// Check if all done
-		if m.SyncingCount == 0 {
-			m.Loading = false
 		}
 
 		return m, tea.Batch(cmds...)
@@ -487,16 +463,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case LogoutCompleteMsg:
 		if msg.Error != nil {
-			m.StatusMsg = fmt.Sprintf("Logout failed: %v", msg.Error)
-			m.StatusIsErr = true
 			m.State = StateBrowsing
-			return m, ClearStatusCmd(5 * time.Second)
+			return m, m.notify(NoticeError, fmt.Sprintf("Logout failed: %v", msg.Error))
 		}
 		// Logout successful - quit the application
 		return m, tea.Quit
 
 	case PlaylistsLoadedMsg:
-		m.Loading = false
 
 		// Validate content ID like every other load handler: a slow playlist
 		// fetch must not clobber whatever column the user navigated to since
@@ -511,7 +484,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case PlaylistItemsLoadedMsg:
-		m.Loading = false
 
 		// Validate content ID to prevent race condition
 		if !m.validateContentID(msg.PlaylistID) {
@@ -526,51 +498,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case PlaylistModalDataMsg:
-		m.StatusMsg = "" // clear the "Loading playlists..." pending status
+		// Clear the "Loading playlists..." pending notice (never an alert)
+		if m.notice.Kind == NoticeInfo {
+			m.clearNotice()
+		}
 		m.PlaylistModal.Show(msg.Playlists, msg.Membership, msg.Item)
 		m.PlaylistModal.SetSize(m.Width, m.Height)
 		return m, nil
 
 	case PlaylistUpdatedMsg:
 		if msg.Error != nil {
-			m.StatusMsg = fmt.Sprintf("Playlist update failed: %v", msg.Error)
-			m.StatusIsErr = true
-		} else {
-			m.StatusMsg = "Playlist updated"
-			// Refresh playlist items if viewing a playlist
-			if m.currentPlaylistID != "" {
-				return m, LoadPlaylistItemsCmd(m.PlaylistService, m.currentPlaylistID)
-			}
+			return m, m.notify(NoticeError, fmt.Sprintf("Playlist update failed: %v", msg.Error))
 		}
-		cmds = append(cmds, ClearStatusCmd(3*time.Second))
+		cmds = append(cmds, m.notify(NoticeSuccess, "Playlist updated"))
+		// Refresh playlist items if viewing a playlist
+		if m.currentPlaylistID != "" {
+			cmds = append(cmds, LoadPlaylistItemsCmd(m.PlaylistService, m.currentPlaylistID))
+		}
 		return m, tea.Batch(cmds...)
 
 	case PlaylistCreatedMsg:
 		if msg.Error != nil {
-			m.StatusMsg = fmt.Sprintf("Failed to create playlist: %v", msg.Error)
-			m.StatusIsErr = true
-		} else {
-			m.StatusMsg = fmt.Sprintf("Created playlist: %s", msg.Playlist.Title)
-			// Refresh playlists if viewing playlists
-			if top := m.ColumnStack.Top(); top != nil && top.ColumnType() == components.ColumnTypePlaylists {
-				return m, LoadPlaylistsCmd(m.PlaylistService)
-			}
+			return m, m.notify(NoticeError, fmt.Sprintf("Failed to create playlist: %v", msg.Error))
 		}
-		cmds = append(cmds, ClearStatusCmd(3*time.Second))
+		cmds = append(cmds, m.notify(NoticeSuccess, fmt.Sprintf("Created playlist: %s", msg.Playlist.Title)))
+		// Refresh playlists if viewing playlists
+		if top := m.ColumnStack.Top(); top != nil && top.ColumnType() == components.ColumnTypePlaylists {
+			cmds = append(cmds, LoadPlaylistsCmd(m.PlaylistService))
+		}
 		return m, tea.Batch(cmds...)
 
 	case PlaylistDeletedMsg:
 		if msg.Error != nil {
-			m.StatusMsg = fmt.Sprintf("Failed to delete playlist: %v", msg.Error)
-			m.StatusIsErr = true
-			cmds = append(cmds, ClearStatusCmd(3*time.Second))
-		} else {
-			m.StatusMsg = "Playlist deleted"
-			// Clear current playlist ID and refresh the playlists
-			m.currentPlaylistID = ""
-			cmds = append(cmds, LoadPlaylistsCmd(m.PlaylistService))
-			cmds = append(cmds, ClearStatusCmd(3*time.Second))
+			return m, m.notify(NoticeError, fmt.Sprintf("Failed to delete playlist: %v", msg.Error))
 		}
+		cmds = append(cmds, m.notify(NoticeSuccess, "Playlist deleted"))
+		// Clear current playlist ID and refresh the playlists
+		m.currentPlaylistID = ""
+		cmds = append(cmds, LoadPlaylistsCmd(m.PlaylistService))
 		return m, tea.Batch(cmds...)
 	}
 
@@ -588,6 +553,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// activeSyncCount returns how many libraries are currently syncing, for the
+// footer's compact background-activity segment
+func (m Model) activeSyncCount() int {
+	n := 0
+	for _, state := range m.LibraryStates {
+		if state.Status == components.StatusSyncing {
+			n++
+		}
+	}
+	return n
 }
 
 // libraryColumn returns the library column (index 0) or nil if not available

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -168,13 +168,6 @@ func TickCmd(delay time.Duration) tea.Cmd {
 	})
 }
 
-// ClearStatusCmd returns a command that clears status after a delay
-func ClearStatusCmd(delay time.Duration) tea.Cmd {
-	return tea.Tick(delay, func(t time.Time) tea.Msg {
-		return ClearStatusMsg{}
-	})
-}
-
 // ClearLibraryStatusCmd returns a command that clears library status after delay
 func ClearLibraryStatusCmd(libID string, delay time.Duration) tea.Cmd {
 	return tea.Tick(delay, func(t time.Time) tea.Msg {

--- a/internal/tui/keyboard.go
+++ b/internal/tui/keyboard.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"time"
-
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mmcdole/kino/internal/tui/components"
@@ -156,8 +154,12 @@ func (m Model) handleEscape() (tea.Model, tea.Cmd) {
 	}
 	if m.navPlan != nil {
 		m.clearNavPlan()
-		m.StatusMsg = "Navigation cancelled"
-		return m, ClearStatusCmd(2 * time.Second)
+		return m, m.notify(NoticeInfo, "Navigation cancelled")
+	}
+	// Esc dismisses a persistent alert once the user has read it
+	if m.notice.Kind == NoticeAlert && m.notice.Text != "" {
+		m.clearNotice()
+		return m, nil
 	}
 	return m, nil
 }
@@ -188,8 +190,10 @@ func (m Model) handleDrillIn() (tea.Model, tea.Cmd) {
 	}
 	if !top.CanDrillInto() {
 		if item := top.SelectedMediaItem(); item != nil {
-			m.StatusMsg = "Launching: " + item.Title
-			return m, PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume())
+			return m, tea.Batch(
+				m.notify(NoticeInfo, "Launching: "+item.Title),
+				PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume()),
+			)
 		}
 		return m, nil
 	}
@@ -207,8 +211,10 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		return m.drillIntoSelection()
 	}
 	if item := top.SelectedMediaItem(); item != nil {
-		m.StatusMsg = "Launching: " + item.Title
-		return m, PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume())
+		return m, tea.Batch(
+			m.notify(NoticeInfo, "Launching: "+item.Title),
+			PlayItemCmd(m.PlaybackSvc, *item, item.ShouldResume()),
+		)
 	}
 	return m, nil
 }
@@ -261,9 +267,6 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.LibraryStates[lib.ID] = components.LibrarySyncState{Status: components.StatusSyncing}
-		m.SyncingCount++
-		m.Loading = true
-		m.MultiLibSync = false
 		m.updateLibraryStates()
 		// Invalidate then sync
 		m.LibraryService.InvalidateLibrary(lib.ID)
@@ -276,7 +279,6 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		// Refresh current show's seasons (invalidate seasons + episodes, re-fetch seasons)
 		m.LibraryService.InvalidateShow(m.currentLibID, m.currentShowID)
 		top.SetRefreshing(true)
-		m.Loading = true
 		return m, LoadSeasonsCmd(m.LibraryService, m.currentLibID, m.currentShowID)
 
 	case components.ColumnTypeEpisodes:
@@ -291,13 +293,11 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		}
 		m.LibraryService.InvalidateSeason(m.currentLibID, m.currentShowID, season.ID)
 		top.SetRefreshing(true)
-		m.Loading = true
 		return m, LoadEpisodesCmd(m.LibraryService, m.currentLibID, m.currentShowID, season.ID)
 
 	case components.ColumnTypePlaylists:
 		// Refresh playlists
 		top.SetRefreshing(true)
-		m.Loading = true
 		return m, LoadPlaylistsCmd(m.PlaylistService)
 
 	case components.ColumnTypePlaylistItems:
@@ -306,7 +306,6 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		top.SetRefreshing(true)
-		m.Loading = true
 		return m, LoadPlaylistItemsCmd(m.PlaylistService, m.currentPlaylistID)
 	}
 
@@ -325,7 +324,6 @@ func (m Model) refreshLibraryContent(top *components.ListColumn) (Model, tea.Cmd
 	}
 	m.LibraryService.InvalidateLibrary(lib.ID)
 	top.SetRefreshing(true)
-	m.Loading = true
 
 	switch lib.Type {
 	case "movie":
@@ -342,8 +340,6 @@ func (m Model) refreshLibraryContent(top *components.ListColumn) (Model, tea.Cmd
 // in place and reloads the visible view, only resetting when the library the
 // user is inside no longer exists.
 func (m Model) handleRefreshAll() (tea.Model, tea.Cmd) {
-	m.Loading = true
-
 	m.LibraryService.InvalidateAll()
 	m.PlaylistService.InvalidatePlaylists()
 	return m, RefreshLibrariesCmd(m.LibraryService)
@@ -385,15 +381,16 @@ func (m Model) handlePlay() (tea.Model, tea.Cmd) {
 	if item == nil {
 		return m.notAvailableHere("Play (p)")
 	}
-	m.StatusMsg = "Launching: " + item.Title
-	return m, PlayItemCmd(m.PlaybackSvc, *item, false)
+	return m, tea.Batch(
+		m.notify(NoticeInfo, "Launching: "+item.Title),
+		PlayItemCmd(m.PlaybackSvc, *item, false),
+	)
 }
 
 // notAvailableHere emits a short status explaining that a key does nothing
 // for the current selection, instead of silently ignoring it
 func (m Model) notAvailableHere(action string) (tea.Model, tea.Cmd) {
-	m.StatusMsg = action + " is not available for this item"
-	return m, ClearStatusCmd(3 * time.Second)
+	return m, m.notify(NoticeInfo, action+" is not available for this item")
 }
 
 // handleToggleInspector toggles the inspector panel visibility
@@ -419,8 +416,10 @@ func (m Model) handlePlaylistModal() (tea.Model, tea.Cmd) {
 	if item == nil || m.PlaylistService == nil {
 		return m.notAvailableHere("Playlists (space)")
 	}
-	m.StatusMsg = "Loading playlists..."
-	return m, LoadPlaylistModalDataCmd(m.PlaylistService, item)
+	return m, tea.Batch(
+		m.notify(NoticeInfo, "Loading playlists..."),
+		LoadPlaylistModalDataCmd(m.PlaylistService, item),
+	)
 }
 
 // handleDelete handles deletion of playlists or playlist items
@@ -444,8 +443,7 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	default:
-		m.StatusMsg = "Remove (x) only works in playlists"
-		return m, ClearStatusCmd(3 * time.Second)
+		return m, m.notify(NoticeInfo, "Remove (x) only works in playlists")
 	}
 	return m, nil
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -77,15 +77,6 @@ type MarkUnwatchedMsg struct {
 // TickMsg is a general tick message for animations
 type TickMsg struct{}
 
-// ClearStatusMsg clears the status bar message
-type ClearStatusMsg struct{}
-
-// StatusMsg sets a temporary status message
-type StatusMsg struct {
-	Message string
-	IsError bool
-}
-
 // LibrarySyncProgressMsg sent for each chunk during streaming sync
 type LibrarySyncProgressMsg struct {
 	LibraryID   string

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mmcdole/kino/internal/domain"
@@ -92,7 +91,6 @@ func (m *Model) pushAndLoadColumn(spec columnLoadSpec, cursor int) *drillResult 
 	}
 
 	col.SetLoading(true)
-	m.Loading = true
 	return &drillResult{
 		AwaitKind: spec.awaitKind,
 		AwaitID:   spec.awaitID,
@@ -124,7 +122,6 @@ func (m *Model) navigateToMixedLibraryItem(lib *domain.Library, targets []NavTar
 
 	mixedCol.SetLoading(true)
 	m.ColumnStack.Push(mixedCol, 0)
-	m.Loading = true
 	m.updateLayout()
 	return LoadMixedLibraryCmd(m.LibraryService, *lib)
 }
@@ -203,7 +200,6 @@ func (m *Model) drillSelected() *drillResult {
 			}
 
 			col.SetLoading(true)
-			m.Loading = true
 			return &drillResult{
 				AwaitKind: AwaitNone,
 				Cmd:       LoadPlaylistsCmd(m.PlaylistService),
@@ -340,7 +336,6 @@ func (m *Model) drillSelected() *drillResult {
 		}
 
 		col.SetLoading(true)
-		m.Loading = true
 		return &drillResult{
 			AwaitKind: AwaitNone, // Playlists don't use the NavPlan system
 			AwaitID:   v.ID,
@@ -427,9 +422,7 @@ func (m *Model) advanceNavPlanAfterLoad(kind NavAwaitKind, id string) tea.Cmd {
 	if target.ID != "" {
 		if !top.SetSelectedByID(target.ID) {
 			m.clearNavPlan()
-			m.StatusMsg = "Item not found (library may have changed)"
-			m.StatusIsErr = true
-			return ClearStatusCmd(5 * time.Second)
+			return m.notify(NoticeError, "Item not found (library may have changed)")
 		}
 	}
 
@@ -445,9 +438,7 @@ func (m *Model) advanceNavPlanAfterLoad(kind NavAwaitKind, id string) tea.Cmd {
 	result := m.drillSelected()
 	if result == nil {
 		m.clearNavPlan()
-		m.StatusMsg = "Navigation failed"
-		m.StatusIsErr = true
-		return ClearStatusCmd(5 * time.Second)
+		return m.notify(NoticeError, "Navigation failed")
 	}
 	// Update navPlan with await info for next load
 	m.navPlan.AwaitKind = result.AwaitKind

--- a/internal/tui/notice.go
+++ b/internal/tui/notice.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// NoticeKind classifies footer notifications. The kind decides styling and
+// lifetime — call sites never pick durations.
+type NoticeKind int
+
+const (
+	NoticeInfo    NoticeKind = iota // neutral event ("Launching: ...")
+	NoticeSuccess                   // completed action ("Marked watched: ...")
+	NoticeError                     // failed action; longer lifetime for reading
+	NoticeAlert                     // needs the user: persists until superseded by another alert or dismissed with Esc
+)
+
+// Notice is the single footer notification slot.
+type Notice struct {
+	Text string
+	Kind NoticeKind
+	Seq  int
+}
+
+const (
+	noticeDurationShort = 3 * time.Second // info & success
+	noticeDurationLong  = 6 * time.Second // errors
+)
+
+// ClearNoticeMsg expires the notice with the matching sequence number.
+// Carrying the sequence means a stale timer from an earlier notice can never
+// clear a newer one.
+type ClearNoticeMsg struct{ Seq int }
+
+// notify posts a footer notification and returns its expiry timer command.
+// Alerts return nil (no timer) and cannot be displaced by non-alert notices.
+func (m *Model) notify(kind NoticeKind, text string) tea.Cmd {
+	if m.notice.Kind == NoticeAlert && m.notice.Text != "" && kind != NoticeAlert {
+		// An active alert outranks transient notices; drop them rather than
+		// hide an actionable message
+		return nil
+	}
+
+	m.noticeSeq++
+	m.notice = Notice{Text: text, Kind: kind, Seq: m.noticeSeq}
+
+	if kind == NoticeAlert {
+		return nil
+	}
+
+	duration := noticeDurationShort
+	if kind == NoticeError {
+		duration = noticeDurationLong
+	}
+	seq := m.noticeSeq
+	return tea.Tick(duration, func(time.Time) tea.Msg {
+		return ClearNoticeMsg{Seq: seq}
+	})
+}
+
+// clearNotice removes the current notice unconditionally (explicit dismiss).
+func (m *Model) clearNotice() {
+	m.notice = Notice{}
+}
+
+// expireNotice clears the notice only if seq still identifies it.
+func (m *Model) expireNotice(seq int) {
+	if m.notice.Seq == seq {
+		m.clearNotice()
+	}
+}

--- a/internal/tui/notice_test.go
+++ b/internal/tui/notice_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import "testing"
+
+func TestNotifySetsNoticeAndTimer(t *testing.T) {
+	m := &Model{}
+
+	cmd := m.notify(NoticeInfo, "hello")
+	if m.notice.Text != "hello" || m.notice.Kind != NoticeInfo {
+		t.Fatalf("notice not set: %+v", m.notice)
+	}
+	if cmd == nil {
+		t.Fatal("transient notice must return an expiry timer")
+	}
+
+	if cmd := m.notify(NoticeAlert, "act now"); cmd != nil {
+		t.Fatal("alerts must not have expiry timers")
+	}
+}
+
+// A stale timer from an earlier notice must not clear a newer one — this was
+// the bug class where "Marked watched"'s timer deleted the persistent auth
+// alert posted a second later.
+func TestStaleTimerCannotClearNewerNotice(t *testing.T) {
+	m := &Model{}
+
+	m.notify(NoticeInfo, "first")
+	firstSeq := m.notice.Seq
+
+	m.notify(NoticeSuccess, "second")
+
+	m.expireNotice(firstSeq) // first notice's timer fires late
+	if m.notice.Text != "second" {
+		t.Fatalf("stale timer cleared newer notice: %+v", m.notice)
+	}
+
+	m.expireNotice(m.notice.Seq) // the right timer clears it
+	if m.notice.Text != "" {
+		t.Fatalf("matching timer failed to clear: %+v", m.notice)
+	}
+}
+
+func TestAlertOutranksTransientNotices(t *testing.T) {
+	m := &Model{}
+
+	m.notify(NoticeAlert, "session expired")
+
+	if cmd := m.notify(NoticeSuccess, "Marked watched"); cmd != nil {
+		t.Fatal("suppressed notice must not schedule a timer")
+	}
+	if m.notice.Text != "session expired" {
+		t.Fatalf("transient notice displaced an alert: %+v", m.notice)
+	}
+
+	// Another alert may replace it
+	m.notify(NoticeAlert, "library gone")
+	if m.notice.Text != "library gone" {
+		t.Fatalf("alert failed to replace alert: %+v", m.notice)
+	}
+
+	// Explicit dismiss always works
+	m.clearNotice()
+	if m.notice.Text != "" {
+		t.Fatal("clearNotice failed")
+	}
+}

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -45,6 +45,15 @@ var (
 
 	ErrorStyle = lipgloss.NewStyle().
 			Foreground(Red)
+
+	// AlertStyle marks persistent, actionable notices (bold to stand apart
+	// from transient errors)
+	AlertStyle = lipgloss.NewStyle().
+			Foreground(Red).
+			Bold(true)
+
+	SuccessStyle = lipgloss.NewStyle().
+			Foreground(Green)
 )
 
 // Raw watch status characters (unstyled)

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -117,50 +117,27 @@ func (m Model) View() string {
 	return view
 }
 
-// renderFooter renders a single-line minimal footer
+// renderFooter renders a single-line minimal footer.
+//
+// Feedback scope rules (see docs/design-review.md and notice.go):
+//   - Row-scoped work (library sync) renders on the row; the footer only
+//     carries a compact activity segment on the right, never full-width text.
+//   - Column-scoped work (loads, refreshes, failures) renders in the column.
+//   - The footer's left side is exclusively the notification slot: transient
+//     events and persistent alerts.
 func (m Model) renderFooter() string {
-	// Left side: spinner + status when loading or status message active
+	// Left side: current notification, styled by kind
 	var left string
-	if m.Loading {
-		statusText := "Loading..."
-
-		if m.MultiLibSync {
-			// Multi-library: stable library completion fraction
-			syncingCount := 0
-			for _, state := range m.LibraryStates {
-				if state.Status == components.StatusSyncing {
-					syncingCount++
-				}
-			}
-			done := len(m.LibraryStates) - syncingCount
-			statusText = fmt.Sprintf("Syncing %d/%d libraries...", done, len(m.LibraryStates))
-		} else {
-			// Single library: show name + item progress
-			for id, state := range m.LibraryStates {
-				if state.Status == components.StatusSyncing {
-					libName := ""
-					for _, lib := range m.Libraries {
-						if lib.ID == id {
-							libName = lib.Name
-							break
-						}
-					}
-					if state.Total > 0 {
-						statusText = fmt.Sprintf("Syncing %s · %d/%d", libName, state.Loaded, state.Total)
-					} else if libName != "" {
-						statusText = fmt.Sprintf("Syncing %s...", libName)
-					}
-					break
-				}
-			}
-		}
-
-		left = RenderSpinner(m.SpinnerFrame) + " " + styles.DimStyle.Render(statusText)
-	} else if m.StatusMsg != "" {
-		if m.StatusIsErr {
-			left = styles.ErrorStyle.Render(m.StatusMsg)
-		} else {
-			left = styles.DimStyle.Render(m.StatusMsg)
+	if m.notice.Text != "" {
+		switch m.notice.Kind {
+		case NoticeAlert:
+			left = styles.AlertStyle.Render(m.notice.Text) + styles.DimStyle.Render("  esc to dismiss")
+		case NoticeError:
+			left = styles.ErrorStyle.Render(m.notice.Text)
+		case NoticeSuccess:
+			left = styles.SuccessStyle.Render(m.notice.Text)
+		default:
+			left = styles.DimStyle.Render(m.notice.Text)
 		}
 	}
 
@@ -175,8 +152,11 @@ func (m Model) renderFooter() string {
 		}
 	}
 
-	// Right side: "? help" hint
+	// Right side: compact background-sync segment + "? help" hint
 	right := styles.AccentStyle.Render("?") + styles.DimStyle.Render(" help")
+	if n := m.activeSyncCount(); n > 0 {
+		right = RenderSpinner(m.SpinnerFrame) + styles.DimStyle.Render(fmt.Sprintf(" %d syncing", n)) + "   " + right
+	}
 
 	// Layout: left + centered hints + right
 	leftWidth := lipgloss.Width(left)


### PR DESCRIPTION
Implements the feedback-consistency redesign discussed in review:

**Scope rule** — feedback renders where the work happens, once:
- Library sync → row spinner/✓/✗ only; the footer never mirrors it full-width. A compact `⠋ 3 syncing` segment sits next to "? help" while background work runs and vanishes when idle.
- Column loads/refreshes/failures → existing column indicators, unchanged.
- Footer left side → notifications only.

**Typed notices** — `Notice{Text, Kind, Seq}`:
- `info`/`success` (3s), `error` (6s), `alert` (persistent until superseded or Esc). Call sites use `m.notify(kind, text)` and never choose durations.
- Clear timers carry the sequence number: a stale timer can't erase a newer message. This fixes a real bug where e.g. "Marked watched"'s 3s timer could delete the persistent re-auth alert posted a second later.
- Alerts can't be displaced by transient notices ("Marked watched" can no longer hide "session expired").
- Sync failures post a scoped error naming the library, since the row's ✗ may be off-screen.

**Deleted**: `Model.Loading`, `MultiLibSync`, `SyncingCount`, `StatusMsg`/`StatusIsErr`, the `StatusMsg`/`ClearStatusMsg` message types (no senders), `ClearStatusCmd`, and the 2s/3s/5s duration zoo across ~25 call sites.

Tested: unit tests for notice sequencing, stale-timer immunity, and alert precedence; e2e against the fake Jellyfin server verified no full-width sync takeover, the compact syncing segment, notices visible during sync, and intact row/column spinners.