### PR TITLE
Fix Windows player discovery and resume handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Config file: `~/.config/kino/config.yaml` (created on first run).
 
 Kino auto-detects video players (mpv, VLC, IINA, Celluloid, etc.) with resume support. See `config.example.yaml` for custom player setup and all options.
 
-On WSL, Windows-side players are detected too (PotPlayer, mpv.exe, VLC), and links fall back to `wslview`/`explorer.exe` instead of `xdg-open`.
+On WSL, Kino detects Windows-side players (PotPlayer, mpv.exe, VLC) from both `PATH` and Windows App Paths, so normal GUI installations work without extra configuration. Native Windows builds use the same detection.
+
+If no media player is available, Kino opens the raw media URL with the platform's default URL handler. This is a best-effort browser fallback: resume is unavailable and some MKV/audio-codec combinations may play without audio. Installing mpv, VLC, or PotPlayer is recommended for reliable playback.
 
 ## License
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,8 +25,8 @@ player:
   # Arguments passed to the player
   args:
     - "--no-terminal"
-  # Flag for specifying start time (e.g., "--start=" for mpv)
-  # start_flag: "--start="
+  # Flag for specifying start time; %d is replaced with elapsed seconds
+  # start_flag: "--start=%d"
 
 # User Interface Configuration
 ui:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,7 @@ type ServerConfig struct {
 type PlayerConfig struct {
 	Command   string   `mapstructure:"command"`
 	Args      []string `mapstructure:"args"`
-	StartFlag string   `mapstructure:"start_flag"` // e.g., "--start=" or "--start-time="
+	StartFlag string   `mapstructure:"start_flag"` // e.g., "--start=%d" or "--start-time=%d"
 }
 
 // UIConfig holds UI configuration

--- a/internal/player/launcher.go
+++ b/internal/player/launcher.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mmcdole/kino/internal/domain"
@@ -16,16 +18,30 @@ import (
 
 // Launcher launches media URLs in an external player
 type Launcher struct {
-	command  string   // configured player command, empty for system default
-	args     []string // additional arguments for the player
-	seekFlag string   // user-configured seek flag (e.g., "--start=%d"), overrides table lookup
-	logger   *slog.Logger
+	command       string   // configured player command, empty for system default
+	args          []string // additional arguments for the player
+	seekFlag      string   // user-configured seek flag (e.g., "--start=%d"), overrides table lookup
+	logger        *slog.Logger
+	detectMu      sync.Mutex
+	detected      ResolvedPlayer
+	detectedFound bool
+	detectedAt    time.Time
 }
 
 // PlayerDef defines a player binary and its seek flag format
 type PlayerDef struct {
-	Binary   string
-	SeekFlag string // Use %d for seconds placeholder, e.g., "--start=%d" or "-ss %d"
+	Binary        string
+	SeekFlag      string   // Use %d for seconds placeholder, e.g., "--start=%d" or "-ss %d"
+	URLBeforeSeek bool     // Some players (notably PotPlayer) expect the media URL before switches
+	ProgramPaths  []string // Conventional paths relative to Windows Program Files roots
+}
+
+// ResolvedPlayer keeps the player identity separate from the executable path.
+// This matters in WSL, where an App Paths lookup returns an absolute Windows
+// install path rather than the short binary name used to select seek behavior.
+type ResolvedPlayer struct {
+	Definition PlayerDef
+	Executable string
 }
 
 // Platform-specific player lists, ordered by priority (first match wins)
@@ -44,14 +60,38 @@ var darwinPlayers = []PlayerDef{
 	{Binary: "vlc", SeekFlag: "--start-time=%d"},
 }
 
-// Windows-side players reachable from WSL via interop. Probed after the
-// native Linux list so a Linux install (e.g. via WSLg) still wins.
-var wslPlayers = []PlayerDef{
-	{Binary: "PotPlayerMini64.exe", SeekFlag: "/seek=%d"},
-	{Binary: "PotPlayerMini.exe", SeekFlag: "/seek=%d"},
-	{Binary: "mpv.exe", SeekFlag: "--start=%d"},
-	{Binary: "vlc.exe", SeekFlag: "--start-time=%d"},
+// Windows players, used both by native Windows and WSL interop. Under WSL they
+// are probed after the native Linux list so an intentional WSLg install wins.
+var windowsPlayers = []PlayerDef{
+	{
+		Binary:        "PotPlayerMini64.exe",
+		SeekFlag:      "/seek=%d",
+		URLBeforeSeek: true,
+		ProgramPaths:  []string{`DAUM\PotPlayer\PotPlayerMini64.exe`},
+	},
+	{
+		Binary:        "PotPlayerMini.exe",
+		SeekFlag:      "/seek=%d",
+		URLBeforeSeek: true,
+		ProgramPaths:  []string{`DAUM\PotPlayer\PotPlayerMini.exe`},
+	},
+	{Binary: "mpv.exe", SeekFlag: "--start=%d", ProgramPaths: []string{`mpv\mpv.exe`}},
+	{Binary: "vlc.exe", SeekFlag: "--start-time=%d", ProgramPaths: []string{`VideoLAN\VLC\vlc.exe`}},
 }
+
+// Kept as an alias because WSL uses the same Windows-side player definitions.
+var wslPlayers = windowsPlayers
+
+var windowsAppPathRoots = []string{
+	`HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths`,
+	`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths`,
+	`HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths`,
+}
+
+const (
+	windowsDiscoveryTimeout = 5 * time.Second
+	negativeDetectionTTL    = 30 * time.Second
+)
 
 func lookPathOK(binary string) bool {
 	_, err := exec.LookPath(binary)
@@ -107,12 +147,20 @@ func (l *Launcher) Launch(url string, startOffset time.Duration) error {
 
 	// Tier 2: Auto-detect known players
 	if player, found := l.detectPlayer(); found {
-		l.logger.Info("auto-detected player", "binary", player.Binary)
-		return l.execPlayer(player, url, offsetSecs)
+		l.logger.Info("auto-detected player", "binary", player.Definition.Binary,
+			"executable", player.Executable)
+		if err := l.execPlayer(player, url, offsetSecs); err != nil {
+			// Do not pin a stale/broken executable for the rest of the process.
+			l.invalidateDetectedPlayer()
+			return err
+		}
+		return nil
 	}
 
-	// Tier 3: System default fallback (xdg-open/open)
-	l.logger.Warn("no video players found, falling back to system default")
+	// Tier 3: Best-effort system URL handler fallback. For HTTP media URLs this
+	// is normally a browser, whose container/codec support is more limited than
+	// a real media player's.
+	l.logger.Warn("no video players found, opening raw media URL with system handler; codec support may be limited")
 	if offsetSecs > 0 {
 		l.logger.Warn("resume not supported with system default player - starting from beginning")
 	}
@@ -120,71 +168,297 @@ func (l *Launcher) Launch(url string, startOffset time.Duration) error {
 }
 
 // detectPlayer returns the first available player from the platform-specific list
-func (l *Launcher) detectPlayer() (PlayerDef, bool) {
+func (l *Launcher) detectPlayer() (ResolvedPlayer, bool) {
+	l.detectMu.Lock()
+	defer l.detectMu.Unlock()
+
+	if l.detectedFound {
+		return l.detected, true
+	}
+	if !l.detectedAt.IsZero() && time.Since(l.detectedAt) < negativeDetectionTTL {
+		return ResolvedPlayer{}, false
+	}
+
+	l.detected, l.detectedFound = detectPlayerUncached()
+	l.detectedAt = time.Now()
+	return l.detected, l.detectedFound
+}
+
+func (l *Launcher) invalidateDetectedPlayer() {
+	l.detectMu.Lock()
+	defer l.detectMu.Unlock()
+	l.detected = ResolvedPlayer{}
+	l.detectedFound = false
+	l.detectedAt = time.Time{}
+}
+
+func detectPlayerUncached() (ResolvedPlayer, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), windowsDiscoveryTimeout)
+	defer cancel()
+
 	var candidates []PlayerDef
+	underWSL := runtime.GOOS == "linux" && isWSL()
+	searchWindowsInstalls := false
 
 	switch runtime.GOOS {
 	case "darwin":
 		candidates = darwinPlayers
 	case "linux":
 		candidates = linuxPlayers
-		if isWSL() {
+		if underWSL {
 			// WSL can execute Windows binaries via interop; a Windows-side
-			// mpv/vlc on PATH is a perfectly good player
+			// player on PATH is a perfectly good player.
 			candidates = append(append([]PlayerDef{}, linuxPlayers...), wslPlayers...)
+			searchWindowsInstalls = true
 		}
+	case "windows":
+		candidates = windowsPlayers
+		searchWindowsInstalls = true
 	default:
-		return PlayerDef{}, false
+		return ResolvedPlayer{}, false
 	}
 
+	// Honor PATH first. In WSL this also ensures an explicitly exposed
+	// Windows player wins over a different player merely found in the registry.
 	for _, p := range candidates {
 		if path, err := exec.LookPath(p.Binary); err == nil && path != "" {
-			return p, true
+			return ResolvedPlayer{Definition: p, Executable: path}, true
 		}
 	}
-	return PlayerDef{}, false
+
+	// CreateProcess/exec.LookPath does not consult Windows "App Paths". GUI
+	// installers commonly register there without adding themselves to PATH, so
+	// query it explicitly on native Windows and through interop on WSL.
+	if searchWindowsInstalls {
+		for _, p := range windowsPlayers {
+			if executable, found := resolveWindowsAppPath(ctx, p, underWSL); found {
+				return ResolvedPlayer{Definition: p, Executable: executable}, true
+			}
+		}
+
+		// App Paths is the authoritative registration mechanism. Only after all
+		// registered candidates miss do we try conventional install locations.
+		programFilesRoots := windowsProgramFilesRoots(ctx, underWSL)
+		for _, p := range windowsPlayers {
+			if executable, found := resolveWindowsProgramPath(ctx, p, programFilesRoots, underWSL); found {
+				return ResolvedPlayer{Definition: p, Executable: executable}, true
+			}
+		}
+	}
+
+	return ResolvedPlayer{}, false
+}
+
+func resolveWindowsAppPath(ctx context.Context, player PlayerDef, underWSL bool) (string, bool) {
+	for _, root := range windowsAppPathRoots {
+		key := root + `\` + player.Binary
+		if windowsPath, found := queryRegistryValue(ctx, key, "/ve"); found {
+			if executable, ok := usableWindowsExecutable(ctx, windowsPath, underWSL); ok {
+				return executable, true
+			}
+		}
+	}
+	return "", false
+}
+
+// resolveWindowsProgramPath checks a short list of conventional locations. It
+// deliberately avoids recursively scanning a mounted Windows drive.
+func resolveWindowsProgramPath(ctx context.Context, player PlayerDef, roots []string, underWSL bool) (string, bool) {
+	for _, root := range roots {
+		for _, relative := range player.ProgramPaths {
+			windowsPath := strings.TrimRight(root, `\/`) + `\` + strings.TrimLeft(relative, `\/`)
+			if executable, ok := usableWindowsExecutable(ctx, windowsPath, underWSL); ok {
+				return executable, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func queryRegistryValue(ctx context.Context, key string, valueArgs ...string) (string, bool) {
+	if !lookPathOK("reg.exe") {
+		return "", false
+	}
+
+	args := append([]string{"query", key}, valueArgs...)
+	output, err := exec.CommandContext(ctx, "reg.exe", args...).Output()
+	if err != nil {
+		return "", false
+	}
+	return parseRegistryString(output)
+}
+
+func parseRegistryString(output []byte) (string, bool) {
+	for _, line := range strings.Split(string(output), "\n") {
+		for _, valueType := range []string{"REG_EXPAND_SZ", "REG_SZ"} {
+			if index := strings.Index(line, valueType); index >= 0 {
+				value := cleanWindowsExecutable(line[index+len(valueType):])
+				return value, value != ""
+			}
+		}
+	}
+	return "", false
+}
+
+func cleanWindowsExecutable(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, `"`) {
+		if end := strings.Index(value[1:], `"`); end >= 0 {
+			return value[1 : end+1]
+		}
+	}
+	return strings.Trim(value, `"`)
+}
+
+func usableWindowsExecutable(ctx context.Context, windowsPath string, underWSL bool) (string, bool) {
+	windowsPath = expandWindowsEnvironment(ctx, windowsPath, underWSL)
+	executable := windowsPath
+	if underWSL {
+		output, err := exec.CommandContext(ctx, "wslpath", "-u", windowsPath).Output()
+		if err != nil {
+			return "", false
+		}
+		executable = strings.TrimSpace(string(output))
+	}
+
+	info, err := os.Stat(executable)
+	return executable, err == nil && !info.IsDir()
+}
+
+var windowsEnvironmentReference = regexp.MustCompile(`%[A-Za-z0-9_()]+%`)
+
+func expandWindowsEnvironment(ctx context.Context, value string, underWSL bool) string {
+	return windowsEnvironmentReference.ReplaceAllStringFunc(value, func(reference string) string {
+		name := reference[1 : len(reference)-1]
+		if !underWSL {
+			if expanded, found := os.LookupEnv(name); found {
+				return expanded
+			}
+			return reference
+		}
+
+		if !lookPathOK("cmd.exe") {
+			return reference
+		}
+		output, err := exec.CommandContext(ctx, "cmd.exe", "/d", "/s", "/c", "echo "+reference).Output()
+		if err != nil {
+			return reference
+		}
+		expanded := strings.TrimSpace(string(output))
+		if expanded == "" || strings.EqualFold(expanded, reference) {
+			return reference
+		}
+		return expanded
+	})
+}
+
+func windowsProgramFilesRoots(ctx context.Context, underWSL bool) []string {
+	if !underWSL {
+		return uniqueNonEmpty(os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)"))
+	}
+
+	const currentVersionKey = `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion`
+	var roots []string
+	for _, valueName := range []string{"ProgramFilesDir", "ProgramFilesDir (x86)"} {
+		if root, found := queryRegistryValue(ctx, currentVersionKey, "/v", valueName); found {
+			roots = append(roots, root)
+		}
+	}
+	return uniqueNonEmpty(roots...)
+}
+
+func uniqueNonEmpty(values ...string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		key := strings.ToLower(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 // execPlayer launches the detected player with optional seek offset
-func (l *Launcher) execPlayer(player PlayerDef, url string, offsetSecs int) error {
-	args := []string{}
+func (l *Launcher) execPlayer(player ResolvedPlayer, url string, offsetSecs int) error {
+	args := playerArgs(player.Definition, url, offsetSecs)
 
-	// Add seek flag if we have an offset and the player supports it
-	if offsetSecs > 0 && player.SeekFlag != "" {
-		formattedFlag := fmt.Sprintf(player.SeekFlag, offsetSecs)
-		// Split flags like "-ss 10" into separate args
-		args = append(args, strings.Fields(formattedFlag)...)
+	l.logger.Debug("executing player", "binary", player.Definition.Binary,
+		"executable", player.Executable, "args", redactTokens(args))
+	return startCommand(exec.Command(player.Executable, args...))
+}
+
+func playerArgs(player PlayerDef, url string, offsetSecs int) []string {
+	seekArgs := formatSeekArgs(player.SeekFlag, offsetSecs)
+	defaultArgs := playerDefaultArgs(player, offsetSecs)
+	if player.URLBeforeSeek {
+		args := append([]string{url}, defaultArgs...)
+		return append(args, seekArgs...)
+	}
+	args := append([]string{}, defaultArgs...)
+	args = append(args, seekArgs...)
+	return append(args, url)
+}
+
+func playerDefaultArgs(player PlayerDef, offsetSecs int) []string {
+	// A running VLC instance can ignore --start-time for a subsequently opened
+	// URL. Keeping auto-detected playback in its own instance makes resume
+	// deterministic; explicitly configured VLC remains under user control.
+	if offsetSecs > 0 && (strings.EqualFold(player.Binary, "vlc.exe") || strings.EqualFold(player.Binary, "vlc")) {
+		return []string{"--no-one-instance"}
+	}
+	return nil
+}
+
+func formatSeekArgs(flag string, offsetSecs int) []string {
+	flag = strings.TrimSpace(flag)
+	if flag == "" || offsetSecs <= 0 {
+		return nil
 	}
 
-	args = append(args, url)
-
-	l.logger.Debug("executing player", "binary", player.Binary, "args", redactTokens(args))
-	cmd := exec.Command(player.Binary, args...)
-	return cmd.Start()
+	offset := strconv.Itoa(offsetSecs)
+	switch {
+	case strings.Contains(flag, "%d"):
+		flag = strings.ReplaceAll(flag, "%d", offset)
+	case strings.HasSuffix(flag, "="):
+		// Backward-compatible with the originally documented "--start=" form.
+		flag += offset
+	default:
+		flag += " " + offset
+	}
+	return strings.Fields(flag)
 }
 
 // launchConfigured launches the media using the user-configured player
 func (l *Launcher) launchConfigured(url string, offsetSecs int) error {
 	args := append([]string{}, l.args...)
+	definition, knownPlayer := l.lookupPlayerDef(l.command)
+	var seekArgs []string
 
 	// Add seek offset: user-configured flag takes precedence, then table lookup
 	if offsetSecs > 0 {
 		seekFlag := l.seekFlag
 		if seekFlag == "" {
 			// Fall back to table lookup for known players
-			seekFlag = l.lookupSeekFlag(l.command)
+			seekFlag = definition.SeekFlag
 		}
 
 		if seekFlag != "" {
-			formattedFlag := fmt.Sprintf(seekFlag, offsetSecs)
-			args = append(args, strings.Fields(formattedFlag)...)
+			seekArgs = formatSeekArgs(seekFlag, offsetSecs)
 		} else {
 			l.logger.Warn("cannot set start offset - unknown player, configure start_flag in config",
 				"command", l.command, "offset", offsetSecs)
 		}
 	}
 
-	args = append(args, url)
+	args = configuredPlayerArgs(args, definition, knownPlayer, url, seekArgs)
 
 	l.logger.Debug("launching configured player", "command", l.command, "args", redactTokens(args))
 
@@ -195,20 +469,44 @@ func (l *Launcher) launchConfigured(url string, offsetSecs int) error {
 		}
 	}
 
-	cmd := exec.Command(l.command, args...)
-	return cmd.Start()
+	return startCommand(exec.Command(l.command, args...))
+}
+
+func configuredPlayerArgs(configuredArgs []string, definition PlayerDef, knownPlayer bool, url string, seekArgs []string) []string {
+	if knownPlayer && definition.URLBeforeSeek {
+		args := append([]string{url}, configuredArgs...)
+		return append(args, seekArgs...)
+	}
+	args := append([]string{}, configuredArgs...)
+	args = append(args, seekArgs...)
+	return append(args, url)
 }
 
 // lookupSeekFlag finds the seek flag for a known player binary
 func (l *Launcher) lookupSeekFlag(binary string) string {
-	for _, table := range [][]PlayerDef{linuxPlayers, darwinPlayers, wslPlayers} {
+	player, _ := l.lookupPlayerDef(binary)
+	return player.SeekFlag
+}
+
+func (l *Launcher) lookupPlayerDef(binary string) (PlayerDef, bool) {
+	wanted := executableName(binary)
+	for _, table := range [][]PlayerDef{linuxPlayers, darwinPlayers, windowsPlayers} {
 		for _, p := range table {
-			if p.Binary == binary {
-				return p.SeekFlag
+			if strings.EqualFold(executableName(p.Binary), wanted) {
+				return p, true
 			}
 		}
 	}
-	return ""
+	return PlayerDef{}, false
+}
+
+func executableName(command string) string {
+	command = strings.Trim(strings.TrimSpace(command), `"`)
+	command = strings.ReplaceAll(command, `\`, "/")
+	if index := strings.LastIndex(command, "/"); index >= 0 {
+		return command[index+1:]
+	}
+	return command
 }
 
 // launchMacOSApp launches a macOS GUI app using 'open -a'
@@ -220,8 +518,7 @@ func (l *Launcher) launchMacOSApp(appName string, playerArgs []string) error {
 	}
 
 	l.logger.Debug("using macOS 'open -a'", "app", appName, "args", redactTokens(cmdArgs))
-	cmd := exec.Command("open", cmdArgs...)
-	return cmd.Start()
+	return startCommand(exec.Command("open", cmdArgs...))
 }
 
 // launchDefault opens the URL using the system default handler
@@ -231,6 +528,13 @@ func (l *Launcher) launchDefault(url string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		cmd = exec.Command("open", url)
+	case "windows":
+		switch {
+		case lookPathOK("rundll32.exe"):
+			cmd = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", url)
+		case lookPathOK("explorer.exe"):
+			cmd = exec.Command("explorer.exe", url)
+		}
 	default:
 		// Linux and other Unix-like systems
 		if isWSL() {
@@ -255,9 +559,24 @@ func (l *Launcher) launchDefault(url string) error {
 			cmd = exec.Command("xdg-open", url)
 		}
 	}
+	if cmd == nil {
+		return fmt.Errorf("no media player or system URL handler found — install mpv (or vlc), or set player.command in config.yaml")
+	}
 
 	l.logger.Debug("launching with system default", "os", runtime.GOOS, "command", cmd.Path)
-	return cmd.Start()
+	return startCommand(cmd)
+}
+
+// startCommand always reaps the child process. Player processes may live for a
+// long time, so waiting happens asynchronously rather than blocking the TUI.
+func startCommand(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return nil
 }
 
 // Service orchestrates playback operations

--- a/internal/player/launcher_test.go
+++ b/internal/player/launcher_test.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,12 +10,13 @@ import (
 	"time"
 )
 
-func fakeBinary(t *testing.T, dir, name string) {
+func fakeBinary(t *testing.T, dir, name string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
+	return path
 }
 
 func forceWSL(t *testing.T) {
@@ -38,11 +40,11 @@ func TestDetectPlayerWSLFindsExe(t *testing.T) {
 	if !found {
 		t.Fatal("mpv.exe not detected under WSL")
 	}
-	if p.Binary != "mpv.exe" {
-		t.Fatalf("detected %q, want mpv.exe", p.Binary)
+	if p.Definition.Binary != "mpv.exe" {
+		t.Fatalf("detected %q, want mpv.exe", p.Definition.Binary)
 	}
-	if p.SeekFlag != "--start=%d" {
-		t.Fatalf("wrong seek flag %q", p.SeekFlag)
+	if p.Definition.SeekFlag != "--start=%d" {
+		t.Fatalf("wrong seek flag %q", p.Definition.SeekFlag)
 	}
 }
 
@@ -59,11 +61,11 @@ func TestDetectPlayerWSLPotPlayerFirst(t *testing.T) {
 
 	l := NewLauncher("", nil, "", nil)
 	p, found := l.detectPlayer()
-	if !found || p.Binary != "PotPlayerMini64.exe" {
-		t.Fatalf("expected PotPlayer to win, got %q (found=%v)", p.Binary, found)
+	if !found || p.Definition.Binary != "PotPlayerMini64.exe" {
+		t.Fatalf("expected PotPlayer to win, got %q (found=%v)", p.Definition.Binary, found)
 	}
-	if p.SeekFlag != "/seek=%d" {
-		t.Fatalf("wrong PotPlayer seek flag %q", p.SeekFlag)
+	if p.Definition.SeekFlag != "/seek=%d" {
+		t.Fatalf("wrong PotPlayer seek flag %q", p.Definition.SeekFlag)
 	}
 }
 
@@ -80,8 +82,154 @@ func TestDetectPlayerWSLPrefersLinuxPlayer(t *testing.T) {
 
 	l := NewLauncher("", nil, "", nil)
 	p, found := l.detectPlayer()
-	if !found || p.Binary != "mpv" {
-		t.Fatalf("expected native mpv to win, got %q (found=%v)", p.Binary, found)
+	if !found || p.Definition.Binary != "mpv" {
+		t.Fatalf("expected native mpv to win, got %q (found=%v)", p.Definition.Binary, found)
+	}
+}
+
+// Windows GUI installers commonly register App Paths without adding their
+// directory to PATH. WSL discovery must resolve and convert that path.
+func TestDetectPlayerWSLFindsWindowsAppPath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+
+	dir := t.TempDir()
+	installed := fakeBinary(t, dir, "installed-vlc.exe")
+	regScript := `#!/bin/sh
+case "$2" in
+  *vlc.exe) printf '\nHKEY_LOCAL_MACHINE\\...\\vlc.exe\n    (Default)    REG_SZ    C:\\Program Files\\VideoLAN\\VLC\\vlc.exe\n' ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "reg.exe"), []byte(regScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	wslpathScript := `#!/bin/sh
+[ "$1" = "-u" ] || exit 1
+[ "$2" = 'C:\Program Files\VideoLAN\VLC\vlc.exe' ] || exit 1
+printf '%s\n' "$FAKE_WSL_EXECUTABLE"
+`
+	if err := os.WriteFile(filepath.Join(dir, "wslpath"), []byte(wslpathScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_WSL_EXECUTABLE", installed)
+	forceWSL(t)
+
+	l := NewLauncher("", nil, "", nil)
+	p, found := l.detectPlayer()
+	if !found {
+		t.Fatal("VLC App Paths entry was not detected under WSL")
+	}
+	if p.Definition.Binary != "vlc.exe" {
+		t.Fatalf("detected %q, want vlc.exe", p.Definition.Binary)
+	}
+	if p.Executable != installed {
+		t.Fatalf("resolved executable = %q, want %q", p.Executable, installed)
+	}
+}
+
+func TestParseRegistryStringQuotedExecutable(t *testing.T) {
+	output := []byte("    (Default)    REG_SZ    \"C:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \r\n")
+	got, found := parseRegistryString(output)
+	if !found {
+		t.Fatal("registry value not parsed")
+	}
+	want := `C:\Program Files\DAUM\PotPlayer\PotPlayerMini64.exe`
+	if got != want {
+		t.Fatalf("registry value = %q, want %q", got, want)
+	}
+}
+
+func TestPlayerArgs(t *testing.T) {
+	t.Run("PotPlayer URL precedes seek switch", func(t *testing.T) {
+		got := playerArgs(windowsPlayers[0], "http://media", 42)
+		want := []string{"http://media", "/seek=42"}
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("configured PotPlayer keeps all switches after URL", func(t *testing.T) {
+		got := configuredPlayerArgs([]string{"/new"}, windowsPlayers[0], true, "http://media", []string{"/seek=42"})
+		want := []string{"http://media", "/new", "/seek=42"}
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("VLC uses separate instance for reliable resume", func(t *testing.T) {
+		got := playerArgs(PlayerDef{Binary: "vlc", SeekFlag: "--start-time=%d"}, "http://media", 42)
+		want := []string{"--no-one-instance", "--start-time=42", "http://media"}
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("VLC play from start can reuse normal instance policy", func(t *testing.T) {
+		got := playerArgs(PlayerDef{Binary: "vlc", SeekFlag: "--start-time=%d"}, "http://media", 0)
+		want := []string{"http://media"}
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+}
+
+func TestFormatSeekArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+		want []string
+	}{
+		{name: "placeholder", flag: "--start=%d", want: []string{"--start=42"}},
+		{name: "legacy equals", flag: "--start=", want: []string{"--start=42"}},
+		{name: "separate value", flag: "-ss", want: []string{"-ss", "42"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := formatSeekArgs(test.flag, 42)
+			if strings.Join(got, "\x00") != strings.Join(test.want, "\x00") {
+				t.Fatalf("formatSeekArgs(%q) = %#v, want %#v", test.flag, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLookupSeekFlagForAbsoluteWindowsPath(t *testing.T) {
+	l := NewLauncher("", nil, "", nil)
+	got := l.lookupSeekFlag(`/mnt/c/Program Files/VideoLAN/VLC/vlc.exe`)
+	if got != "--start-time=%d" {
+		t.Fatalf("seek flag = %q, want --start-time=%%d", got)
+	}
+}
+
+func TestExpandWindowsEnvironment(t *testing.T) {
+	t.Setenv("ProgramFiles", `D:\Applications`)
+	got := expandWindowsEnvironment(context.Background(), `%ProgramFiles%\VideoLAN\VLC\vlc.exe`, false)
+	want := `D:\Applications\VideoLAN\VLC\vlc.exe`
+	if got != want {
+		t.Fatalf("expanded path = %q, want %q", got, want)
+	}
+}
+
+func TestRegistryQueryHonorsContext(t *testing.T) {
+	dir := t.TempDir()
+	regScript := "#!/bin/sh\nexec /bin/sleep 2\n"
+	if err := os.WriteFile(filepath.Join(dir, "reg.exe"), []byte(regScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if _, found := queryRegistryValue(ctx, `HKLM\Software\Example`, "/ve"); found {
+		t.Fatal("timed-out registry query unexpectedly returned a value")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("registry query ignored context; elapsed %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Problem

Under WSL, Kino fell back to the Windows browser when it could not find a player on `PATH`. That sent Plex's raw MKV URL to Edge. The H.264 video played, but Edge exposed no usable E-AC-3 audio track, so playback was silent even though PotPlayer was installed on Windows.

Windows GUI players are commonly registered through App Paths without being added to `PATH`, which made them invisible to the existing launcher.

## Launch behavior

The launcher now uses this order:

1. The player configured in `player.command`
2. A known player available on the current platform's `PATH`
3. On WSL and Windows, PotPlayer, mpv, or VLC found through Windows App Paths or Program Files
4. The platform's default URL handler

WSL continues to prefer a Linux/WSLg player over a Windows player. Linux and macOS player priorities are unchanged. The browser remains a last-resort fallback; it does not support resume and may not support every container/audio-codec combination.

## Changes

- Resolve Windows player installations without assuming Windows is mounted at `/mnt/c`
- Add native Windows player discovery and URL-handler fallback
- Preserve player identity when discovery returns an absolute path, so the correct resume flags are still used
- Put the URL before PotPlayer switches and use a separate VLC instance when resuming
- Support `%d` seek placeholders while retaining the documented legacy `--start=` form
- Bound Windows discovery to five seconds, cache results, and discard a cached player after a launch failure
- Reap launched child processes without blocking the TUI
- Document the browser fallback and its codec limitations

## Testing

- `go test -count=1 -timeout=120s ./...`
- `go test -race -count=1 ./internal/player`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/kino-player-windows.test.exe ./internal/player`
- `GOOS=darwin GOARCH=amd64 go test -c -o /tmp/kino-player-darwin.test ./internal/player`
- Confirmed from WSL that App Paths resolves the installed `PotPlayerMini64.exe`
